### PR TITLE
Version bump to v0.5.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
This should tag the changes introduced in https://github.com/JuliaApproximation/ApproxFunBase.jl/commit/3fa958b49d87d40c289c29d6c21ea58f9cb1bb8c. I had forgotten to bump the patch version in that PR.