### PR TITLE
Accept callables in Fun constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -80,14 +80,14 @@ Fun(f::Fun,::Type{T}) where {T<:Space} = Fun(f,T(domain(f)))
 
 
 Fun(f,T::Type) = Fun(dynamic(f),T())
-Fun(f::Function,T::Type,n::Integer) = Fun(dynamic(f),T(),n)
+Fun(f,T::Type,n::Integer) = Fun(dynamic(f),T(),n)
 
 Fun(f::AbstractVector,d::Domain) = Fun(f,Space(d))
 Fun(d::Domain,f::AbstractVector{T}) where {T<:Number} = Fun(Space(d),f)
 Fun(d::Domain,f::AbstractVector) = Fun(Space(d),f)
 
 
-Fun(f::Function,d::Domain,n) = Fun(dynamic(f),Space(d),n)
+Fun(f,d::Domain,n) = Fun(dynamic(f),Space(d),n)
 
 
 # We do zero special since zero exists even when one doesn't
@@ -170,11 +170,11 @@ Fun(f::typeof(zero), d::Space) = zeros(eltype(domain(d)),d)
 Fun(f::typeof(one), d::Space) = ones(eltype(domain(d)),d)
 
 Fun(f::Type, d::Domain) = Fun(f,Space(d))
-Fun(f::Function, d::Domain) = Fun(f,Space(d))
+Fun(f, d::Domain) = Fun(f,Space(d))
 
 
 # this is the main constructor
-Fun(f::Function, d::Space) = default_Fun(dynamic(f), d)
+Fun(f, d::Space) = default_Fun(dynamic(f), d)
 
 # this supports expanding a Fun to a larger or smaller domain.
 # we take the union and then intersection to get at any singularities


### PR DESCRIPTION
Tests are yet to be added, but this allows non-`Function` callable structs to be passed to the `Fun` constructor, such as an interpolation instance. This and makes it easy to e.g. generate a Chebyshev interpolation from a spline interpolation computed using another package.

```julia
julia> using ApproxFun

julia> struct Foo end

julia> (::Foo)(x) = 2

julia> Fun(Foo(), Chebyshev())
Fun(Chebyshev(),[2.0])
```

The current workaround is using 
```julia
Fun(x -> Foo()(x), Chebyshev())
```
which seems redundant.