### PR TITLE
Avoid pirating `Base.real`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -23,7 +23,7 @@ import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !, 
                 isless, union, angle, join, isnan, isapprox, isempty, sort, merge, promote_rule,
                 minimum, maximum, extrema, argmax, argmin, findmax, findmin, isfinite,
                 zeros, zero, one, promote_rule, repeat, length, resize!, isinf,
-                getproperty, findfirst, unsafe_getindex, fld, cld, div, real, imag,
+                getproperty, findfirst, unsafe_getindex, fld, cld, div, imag,
                 @_inline_meta, eachindex, firstindex, lastindex, keys, isreal, OneTo,
                 Array, Vector, Matrix, view, ones, @propagate_inbounds, print_array,
                 split, iszero, permutedims

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -430,8 +430,8 @@ end
 
 transpose(f::Fun) = f  # default no-op
 
-for op = (:(real),:(imag),:(conj))
-    @eval ($op)(f::Fun{S}) where {S<:RealSpace} = Fun(f.space,($op)(f.coefficients))
+for op = (:real, :imag, :conj)
+    @eval Base.$op(f::Fun{S}) where {S<:RealSpace} = Fun(f.space, ($op)(f.coefficients))
 end
 
 conj(f::Fun) = error("Override conj for $(typeof(f))")

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -12,6 +12,16 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
         @test f/a == Fun(x->(x-0.1)*exp(-x),space(f))
 
         f = Fun(space(f),[1.,2.,3.])
+
+        @testset "real/complex coefficients" begin
+            c = [1:4;]
+            for c2 in Any[c, c*im]
+                g = Fun(PointSpace(1:4), c2)
+                for fn in [real, imag, conj]
+                    @test coefficients(fn(g)) == fn(c2)
+                end
+            end
+        end
     end
 
     @testset "Derivative operator for HeavisideSpace" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,11 @@ import ApproxFunBase: ∞
             [(1,1),(1,2),(2,1),(2,2),(3,1),(3,2)]
     end
 
+    @testset "issue #94" begin
+        @test ApproxFunBase.real !== Base.real
+        @test_throws MethodError ApproxFunBase.real(1,2)
+    end
+
     # TODO: Tensorizer tests
 end
 


### PR DESCRIPTION
Fixes #94 by ensuring that `Base.real` and `ApproxFunBase.real` are separate functions. Tests for `ApproxFun` pass locally with this.