### PR TITLE
Remove allocations in hasnumargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -31,8 +31,7 @@ promote_rule(::Type{UnsetNumber},::Type{N}) where {N<:Number} = N
 promote_rule(::Type{Bool}, ::Type{UnsetNumber}) = Bool
 
 # Test the number of arguments a function takes
-hasnumargs(f,k) = applicable(f,zeros(k)...)
-
+hasnumargs(f,k) = k == 1 ? applicable(f, 0.0) : applicable(f, (1.0:k)...)
 
 # fast implementation of isapprox with atol a non-keyword argument in most cases
 isapprox_atol(a,b,atol;kwds...) = isapprox(a,b;atol=atol,kwds...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,13 @@ import ApproxFunBase: ∞
         @test_throws MethodError ApproxFunBase.real(1,2)
     end
 
+    @testset "hasnumargs" begin
+        onearg(x) = x
+        twoargs(x, y) = x + y
+        @test ApproxFunBase.hasnumargs(onearg, 1)
+        @test ApproxFunBase.hasnumargs(twoargs, 2)
+    end
+
     # TODO: Tensorizer tests
 end
 


### PR DESCRIPTION
On master
```julia
julia> @btime ApproxFunBase.hasnumargs(x->x, 1)
  199.208 ns (2 allocations: 80 bytes)
true

julia> @btime ApproxFunBase.hasnumargs((x,y)->x+y, 2)
  234.893 ns (3 allocations: 112 bytes)
true
```

This PR
```julia
julia> @btime ApproxFunBase.hasnumargs(x->x, 1)
  57.413 ns (0 allocations: 0 bytes)
true

julia> @btime ApproxFunBase.hasnumargs((x,y)->x+y, 2)
  77.941 ns (0 allocations: 0 bytes)
true
```
I've not added a test for zero allocations, as this is often unreliable in my experience in the test environment.