### PR TITLE
Make the `Fun` constructor type-inferrable

### DIFF
--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -641,8 +641,8 @@ end
 
 ## Dynamic functions
 
-struct DFunction <: Function
-    f
+struct DFunction{F} <: Function
+    f :: F
 end
 (f::DFunction)(args...) = f.f(args...)
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -97,7 +97,10 @@ Fun(c::Number,d::Space) = c==0 ? c*zeros(prectype(d),d) : c*ones(prectype(d),d)
 
 ## Adaptive constructors
 function default_Fun(f, d::Space)
-    hasnumargs(f,1) || return Fun(xy->f(xy...),d)
+    _default_Fun(hasnumargs(f, 1) ? f : Base.splat(f), d)
+end
+# In _default_Fun, we know that the function takes a single argument
+function _default_Fun(f, d::Space)
     isinf(dimension(d)) || return Fun(f,d,dimension(d))  # use exactly dimension number of sample points
 
     #TODO: reuse function values?
@@ -108,10 +111,7 @@ function default_Fun(f, d::Space)
 
     isa(f0,AbstractArray) && size(d) ≠ size(f0) && return Fun(f,Space(fill(d,size(f0))))
 
-
-
     tol =T==Any ? 20eps() : 20eps(T)
-
 
     fr=map(f,r)
     maxabsfr=norm(fr,Inf)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -129,7 +129,7 @@ function _default_Fun(f, d::Space)
 
         # we allow for transformed coefficients being a different size
         ##TODO: how to do scaling for unnormalized bases like Jacobi?
-        if ncoefficients(cf) > 8 && maximum(abs,cf.coefficients[bs:end]) < 10tol*maxabsc &&
+        if ncoefficients(cf) > 8 && maximum(abs, @view cf.coefficients[bs:end]) < 10tol*maxabsc &&
                 all(k->norm(cf(r[k])-fr[k],1)<tol*length(cf.coefficients)*maxabsfr*1000,1:length(r))
             return chop!(cf,tol)
         end

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -5,11 +5,11 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
     @testset "PointSpace" begin
         @test eltype(domain(PointSpace([0,0.1,1])) ) == Float64
 
-        f=Fun(x->(x-0.1),PointSpace([0,0.1,1]))
+        f = @inferred Fun(x->(x-0.1),PointSpace([0,0.1,1]))
         @test roots(f) == [0.1]
 
-        a=Fun(exp,space(f))
-        @test f/a == Fun(x->(x-0.1)*exp(-x),space(f))
+        a = @inferred Fun(exp, space(f))
+        @test f/a == @inferred Fun(x->(x-0.1)*exp(-x),space(f))
 
         f = Fun(space(f),[1.,2.,3.])
 


### PR DESCRIPTION
I don't really see a slowdown with this, looking at the test runtimes.
On master (types aren't inferred)
```julia
julia> @time Fun(x->2, Chebyshev()) # first execution
  4.478566 seconds (9.03 M allocations: 534.299 MiB, 11.28% gc time, 99.91% compilation time)
Fun(Chebyshev(),[2.0])

julia> @code_typed Fun(x->x, Chebyshev())
CodeInfo(
1 ─ %1 = invoke ApproxFunBase.default_Fun(ApproxFunBase.DFunction(var"#1#2"())::ApproxFunBase.DFunction, d::Chebyshev{ChebyshevInterval{Float64}, Float64})::Any
└──      return %1
) => Any

julia> @btime Fun(x->x, Chebyshev());
  21.116 μs (106 allocations: 4.88 KiB)
```
This PR (types are inferred now)
```julia
julia> @time Fun(x->2, Chebyshev()) # first execution
  4.586365 seconds (9.21 M allocations: 537.594 MiB, 16.58% gc time, 99.95% compilation time)
Fun(Chebyshev(),[2.0])

julia> @code_typed Fun(x->x, Chebyshev())
CodeInfo(
1 ─ %1 = invoke ApproxFunBase.default_Fun(ApproxFunBase.DFunction{var"#1#2"}(var"#1#2"())::Function, d::Chebyshev{ChebyshevInterval{Float64}, Float64})::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}
└──      return %1
) => Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}

julia> @btime Fun(x->x, Chebyshev());
  15.533 μs (65 allocations: 4.05 KiB)
```
The TTFX is identical (within noise levels), while subsequent evaluation times improve.