### PR TITLE
Fix convert methods to always return the exact type

### DIFF
--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -80,19 +80,23 @@ coefficient(f::Fun,::Colon) = coefficient(f,1:dimension(space(f)))
 
 
 convert(::Type{Fun{S,T,VT}},f::Fun{S}) where {T,S,VT} =
-    Fun(f.space,convert(VT,f.coefficients))
-convert(::Type{Fun{S,T,VT}},f::Fun) where {T,S,VT} =
-    Fun(Fun(f.space,convert(VT,f.coefficients)),convert(S,space(f)))
+    Fun{S,T,VT}(f.space, convert(VT,f.coefficients)::VT)
+function convert(::Type{Fun{S,T,VT}},f::Fun) where {T,S,VT}
+    g = Fun(Fun(f.space, convert(VT,f.coefficients)::VT), convert(S,space(f))::S)
+    Fun{S,T,VT}(g.space, g.coefficients)
+end
 
-convert(::Type{Fun{S,T}},f::Fun{S}) where {T,S} =
-    Fun(f.space,convert(AbstractVector{T},f.coefficients))
+function convert(::Type{Fun{S,T}},f::Fun{S}) where {T,S}
+    coeff = convert(AbstractVector{T},f.coefficients)::AbstractVector{T}
+    Fun{S, T, typeof(coeff)}(f.space, coeff)
+end
 
 
 convert(::Type{VFun{S,T}},x::Number) where {T,S} =
-    x==0 ? zeros(T,S(AnyDomain())) : x*ones(T,S(AnyDomain()))
+    (x==0 ? zeros(T,S(AnyDomain())) : x*ones(T,S(AnyDomain())))::VFun{S,T}
 convert(::Type{Fun{S}},x::Number) where {S} =
-    x==0 ? zeros(S(AnyDomain())) : x*ones(S(AnyDomain()))
-convert(::Type{IF},x::Number) where {IF<:Fun} = convert(IF,Fun(x))
+    (x==0 ? zeros(S(AnyDomain())) : x*ones(S(AnyDomain())))::Fun{S}
+convert(::Type{IF},x::Number) where {IF<:Fun} = convert(IF,Fun(x))::IF
 
 Fun{S,T,VT}(f::Fun) where {S,T,VT} = convert(Fun{S,T,VT}, f)
 Fun{S,T}(f::Fun) where {S,T} = convert(Fun{S,T}, f)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -13,6 +13,20 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
 
         f = Fun(space(f),[1.,2.,3.])
 
+        @testset "conversions" begin
+            @testset for S in Any[typeof(space(f)), Any]
+                T = Fun{S, Any, Any}
+                fany = convert(T, f)
+                @test fany isa T
+                @test (@inferred oftype(f, fany)) isa typeof(f)
+            end
+            S = typeof(space(f))
+            T = Fun{S, Any}
+            fany = convert(T, f)
+            @test fany isa T
+            @test (@inferred oftype(f, fany)) isa typeof(f)
+        end
+
         @testset "real/complex coefficients" begin
             c = [1:4;]
             for c2 in Any[c, c*im]

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -103,4 +103,10 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
         @test @inferred(domain(a^3)) == domain(a)^3
         @test_broken @inferred(points(a^3)) == vec(Vec.(points(a), points(a)', reshape(points(a), 1,1,4)))
     end
+
+    @testset "ConstantSpace" begin
+        @test (@inferred convert(Fun, 2)) == Fun(2)
+        f = Fun(2)
+        @test (@inferred convert(Fun{typeof(space(f))}, 2)) == f
+    end
 end


### PR DESCRIPTION
On master
```julia
julia> f = Fun(x->2, Chebyshev())
Fun(Chebyshev(),[2.0])

julia> @code_typed (f -> oftype(f, Fun(x->2, Chebyshev())))(f)
CodeInfo(
1 ─ %1 = invoke ApproxFunBase.default_Fun(ApproxFunBase.DFunction(var"#16#18"())::ApproxFunBase.DFunction, $(QuoteNode(Chebyshev()))::Chebyshev{ChebyshevInterval{Float64}, Float64})::Any
│   %2 = Main.oftype(f, %1)::Any
└──      return %2
) => Any
```
This PR
```julia
julia> @code_typed (f -> oftype(f, Fun(x->2, Chebyshev())))(f)
CodeInfo(
1 ─ %1 = invoke ApproxFunBase.default_Fun(ApproxFunBase.DFunction(var"#8#10"())::ApproxFunBase.DFunction, $(QuoteNode(Chebyshev()))::Chebyshev{ChebyshevInterval{Float64}, Float64})::Any
│   %2 = Main.oftype(f, %1)::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}
└──      return %2
) => Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}
```

This PR firstly ensures that `convert(T, f::Fun) isa T` for all combinations, and also helps with inference in cases where `f` is not type-inferred.