### PR TITLE
avoid recursion in intpow

### DIFF
--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -363,10 +363,13 @@ function intpow(f::Fun,k::Integer)
         ones(space(f))
     elseif k==1
         f
-    elseif k > 1
-        f*f^(k-1)
     else
-        1/f^(-k)
+        t = reduce(*, fill(f, abs(k)))
+        if k > 0
+            return t
+        else
+            return 1/t
+        end
     end
 end
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -37,11 +37,11 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
             end
         end
         @testset "intpow" begin
-            @test f^0 == Fun(space(f), ones(ncoefficients(f)))
-            @test f^1 == f
-            @test f^2 == f*f
-            @test f^3 == f*f*f
-            @test f^-2 == 1/(f*f)
+            @test ApproxFunBase.intpow(f, 0) == f^0 == Fun(space(f), ones(ncoefficients(f)))
+            for n in 1:3
+                @test ApproxFunBase.intpow(f, n) == f^n == reduce(*, fill(f, n))
+            end
+            @test ApproxFunBase.intpow(f,-2) == f^-2 == 1/(f*f)
         end
     end
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -36,6 +36,13 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
                 end
             end
         end
+        @testset "intpow" begin
+            @test f^0 == Fun(space(f), ones(ncoefficients(f)))
+            @test f^1 == f
+            @test f^2 == f*f
+            @test f^3 == f*f*f
+            @test f^-2 == 1/(f*f)
+        end
     end
 
     @testset "Derivative operator for HeavisideSpace" begin


### PR DESCRIPTION
This helps with type inference in `intpow`, although it's not fully inferred because of negative exponents. This provides a minor performance boost.
On master
```julia
julia> f = Fun(x->x, Chebyshev())
Fun(Chebyshev(),[0.0, 1.0])

julia> @btime $f^6;
  5.611 μs (45 allocations: 2.42 KiB)
```
this PR
```julia
julia> @btime $f^6;
  5.330 μs (52 allocations: 2.61 KiB)
```