### PR TITLE
Avoid pirating dot

### DIFF
--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -33,7 +33,7 @@ import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, broadcas
 
 import Statistics: mean
 
-import LinearAlgebra: BlasInt, BlasFloat, norm, ldiv!, mul!, det, eigvals, dot, cross,
+import LinearAlgebra: BlasInt, BlasFloat, norm, ldiv!, mul!, det, eigvals, cross,
                         qr, qr!, rank, isdiag, istril, istriu, issymmetric, ishermitian,
                         Tridiagonal, diagm, diagm_container, factorize, nullspace,
                         Hermitian, Symmetric, adjoint, transpose, char_uplo

--- a/src/Caching/almostbanded.jl
+++ b/src/Caching/almostbanded.jl
@@ -390,14 +390,14 @@ function resizedata!(QR::QROperator{CachedOperator{T,AlmostBandedMatrix{T},
 
         for j=k:k+R.u
             v=r+sz*(R.u + (k-1)*st + (j-k)*(st-1))
-            dt = BandedMatrices.dot(M,wp,1,v,1)
+            dt = dot(M,wp,1,v,1)
             BLAS.axpy!(M,-2*dt,wp,1,v,1)
         end
 
         for j=k+R.u+1:k+R.u+M-1
             p=j-k-R.u
             v=r+sz*((j-1)*st)  # shift down each time
-            dt = BandedMatrices.dot(M-p,wp+p*sz,1,v,1)
+            dt = dot(M-p,wp+p*sz,1,v,1)
             for ℓ=k:k+p-1
                 @inbounds dt=muladd(conj(W[ℓ-k+1,k]),
                                     unsafe_getindex(MO.data.fill,ℓ,j),dt)
@@ -409,7 +409,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,AlmostBandedMatrix{T},
         fst=stride(F,2)
         for j=1:size(F,2)
             v=fp+fst*(j-1)*sz   # the k,jth entry of F
-            dt = BandedMatrices.dot(M,wp,1,v,1)
+            dt = dot(M,wp,1,v,1)
             BLAS.axpy!(M,-2*dt,wp,1,v,1)
         end
     end

--- a/src/Caching/banded.jl
+++ b/src/Caching/banded.jl
@@ -132,14 +132,14 @@ function resizedata!(QR::QROperator{<:CachedOperator{T,<:BandedMatrix{T},
 
         for j=k:k+R.u
             v=r+sz*(R.u + (k-1)*st + (j-k)*(st-1))
-            dt = BandedMatrices.dot(M,wp,1,v,1)
+            dt = dot(M,wp,1,v,1)
             BLAS.axpy!(M,-2*dt,wp,1,v,1)
         end
 
         for j=k+R.u+1:k+R.u+M-1
             p=j-k-R.u
             v=r+sz*((j-1)*st)  # shift down each time
-            dt = BandedMatrices.dot(M-p,wp+p*sz,1,v,1)
+            dt = dot(M-p,wp+p*sz,1,v,1)
             BLAS.axpy!(M-p,-2*dt,wp+p*sz,1,v,1)
         end
     end

--- a/src/Caching/blockbanded.jl
+++ b/src/Caching/blockbanded.jl
@@ -283,7 +283,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,BlockBandedMatrix{T},
          for ξ_2 = ξ:length(bs.axes[2][Block(J1)])
              # we now apply I-2v*v' in place
              r_sh = r+sz*(shft + st*(ξ_2-ξ)) # the pointer the (j,ξ_2)-th entry
-             dt = BandedMatrices.dot(M, wp, 1, r_sh, 1)
+             dt = dot(M, wp, 1, r_sh, 1)
              BLAS.axpy!(M, -2*dt, wp, 1, r_sh ,1)
          end
 

--- a/src/Caching/matrix.jl
+++ b/src/Caching/matrix.jl
@@ -139,7 +139,7 @@ function mulpars(Ac::Adjoint{T,<:QROperatorQ{QROperator{RR,Matrix{T},T},T}},
         wp=h+sz*st*(k-1)
         yp=y+sz*(k-1)
 
-        dt = BandedMatrices.dot(M,wp,1,yp,1)
+        dt = dot(M,wp,1,yp,1)
         BLAS.axpy!(M,-2*dt,wp,1,yp,1)
         k+=1
     end

--- a/src/Caching/ragged.jl
+++ b/src/Caching/ragged.jl
@@ -83,7 +83,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,RaggedMatrix{T},
             for j=m+1:MO.datasize[2]
                 kr=J:J+length(wp)-1
                 v=view(MO.data,kr,j)
-                dt=BandedMatrices.dot(wp,v)
+                dt=dot(wp,v)
                 LinearAlgebra.axpy!(-2*dt,wp,v)
             end
         end
@@ -114,7 +114,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,RaggedMatrix{T},
         kr=k:k+length(wp)-1
         for j=k:MO.datasize[2]
             v=view(MO.data,kr,j)
-            dt=BandedMatrices.dot(wp,v)
+            dt=dot(wp,v)
             LinearAlgebra.axpy!(-2*dt,wp,v)
         end
     end
@@ -156,7 +156,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,RaggedMatrix{T},
 
             for j=m+1:MO.datasize[2]
                 v=r+(R.cols[j]+k-2)*sz
-                dt=BandedMatrices.dot(M,wp,1,v,1)
+                dt=dot(M,wp,1,v,1)
                 BLAS.axpy!(M,-2*dt,wp,1,v,1)
             end
         end
@@ -192,7 +192,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,RaggedMatrix{T},
         # scale rows entries
         for j=k:MO.datasize[2]
             v=r+(R.cols[j]+k-2)*sz
-            dt=BandedMatrices.dot(M,wp,1,v,1)
+            dt=dot(M,wp,1,v,1)
             BLAS.axpy!(M,-2*dt,wp,1,v,1)
         end
     end
@@ -269,7 +269,7 @@ function mulpars(Ac::Adjoint{T,<:QROperatorQ{QROperator{RR,RaggedMatrix{T},T},T}
         wp=view(H,cr,k)
         yp=view(Y,k-1+(cr))
 
-        dt=BandedMatrices.dot(wp,yp)
+        dt=dot(wp,yp)
         LinearAlgebra.axpy!(-2*dt,wp,yp)
         k+=1
     end
@@ -325,7 +325,7 @@ function mulpars(Ac::Adjoint{T,<:QROperatorQ{QROperator{RR,RaggedMatrix{T},T},T}
         wp=h + sz*(H.cols[k]-1)
         yp=y+sz*(k-1)
 
-        dt = BandedMatrices.dot(M,wp,1,yp,1)
+        dt = dot(M,wp,1,yp,1)
         BLAS.axpy!(M,-2*dt,wp,1,yp,1)
         k+=1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,12 @@ import ApproxFunBase: ∞
         @test ApproxFunBase.hasnumargs(onearg, 1)
         @test ApproxFunBase.hasnumargs(twoargs, 2)
     end
+    @testset "don't pirate dot" begin
+        @test ApproxFunBase.dot !== LinearAlgebra.dot
+        struct DotTester end
+        # check that unknown types don't lead to a stack overflow
+        @test_throws MethodError ApproxFunBase.dot(DotTester())
+    end
 
     # TODO: Tensorizer tests
 end


### PR DESCRIPTION
Currently, `ApproxFunBase.dot` is an alias for `LinearAlgebra.dot`, which makes some of these methods defined here commit type-piracy. This PR solves this.

Problematic methods on master:
https://github.com/JuliaApproximation/ApproxFunBase.jl/blob/eeb33d47aa797b9482e363f53b97241d7a058042/src/LinearAlgebra/helper.jl#L5-L9

Also, since
```julia
julia> @which BandedMatrices.dot
LinearAlgebra
```
these method calls may be replaced by `ApproxFunBase.dot`.