### PR TITLE
Replace non-breaking spaces with regular ones

### DIFF
--- a/src/Caching/almostbanded.jl
+++ b/src/Caching/almostbanded.jl
@@ -19,7 +19,7 @@ function CachedOperator(io::InterlaceOperator{T,1};padding::Bool=false) where T
     nds=0
     md=0
     for k=1:length(io.ops)
-        if k ≠ i
+        if k ≠ i
             d=dimension(rs[k])
             nds+=d
             md=max(md,d)
@@ -57,7 +57,7 @@ function CachedOperator(io::InterlaceOperator{T,1};padding::Bool=false) where T
     for k=1:n
         K,J=io.rangeinterlacer[k]
 
-        if K ≠ i
+        if K ≠ i
             # fill the fill matrix
             ret.fill.V[:,bcrow] = Matrix(view(io.ops[K],J:J,jr))
             ret.fill.U[k,bcrow] = 1
@@ -104,13 +104,13 @@ function CachedOperator(io::InterlaceOperator{T,2};padding::Bool=false) where T
     # we only support block size 1 for now
     for k in d∞
         bl = blocklengths(ds[k])
-        if !(bl isa AbstractFill) || getindex_value(bl) ≠ 1
+        if !(bl isa AbstractFill) || getindex_value(bl) ≠ 1
             return default_CachedOperator(io;padding=padding)
         end
     end
     for k in r∞
         bl = blocklengths(rs[k])
-        if !(bl isa AbstractFill) || getindex_value(bl) ≠ 1
+        if !(bl isa AbstractFill) || getindex_value(bl) ≠ 1
             return default_CachedOperator(io;padding=padding)
         end
     end
@@ -191,7 +191,7 @@ function resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},
 
     k=1
     for (K,J) in co.op.rangeinterlacer
-        if K ≠ ind
+        if K ≠ ind
             co.data.fill.V[co.datasize[2]:end,k] = co.op.ops[K][J,co.datasize[2]:n+u]
             k += 1
             if k > r
@@ -240,7 +240,7 @@ function resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},
 
     # fill rows
     K=k=1
-    while k ≤ r
+    while k ≤ r
         if isfinite(dimension(rs[ri[K][1]]))
             co.data.fill.V[co.datasize[2]:end,k] = co.op[K,co.datasize[2]:n+u]
             k += 1
@@ -287,7 +287,7 @@ end
 function resizedata!(QR::QROperator{CachedOperator{T,AlmostBandedMatrix{T},
                                                   MM,DS,RS,BI}},
          ::Colon,col) where {T,MM,DS,RS,BI}
-    if col ≤ QR.ncols
+    if col ≤ QR.ncols
         return QR
     end
 
@@ -353,7 +353,7 @@ end
 function resizedata!(QR::QROperator{CachedOperator{T,AlmostBandedMatrix{T},
                                        MM,DS,RS,BI}},
 ::Colon,col) where {T<:BlasFloat,MM,DS,RS,BI}
-    if col ≤ QR.ncols
+    if col ≤ QR.ncols
         return QR
     end
 

--- a/src/Caching/banded.jl
+++ b/src/Caching/banded.jl
@@ -43,7 +43,7 @@ end
 function resizedata!(QR::QROperator{<:CachedOperator{T,<:BandedMatrix{T},
                                                   MM,DS,RS,BI}},
          ::Colon,col) where {T,MM,DS,RS,BI}
-    if col ≤ QR.ncols
+    if col ≤ QR.ncols
         return QR
     end
 
@@ -96,7 +96,7 @@ end
 function resizedata!(QR::QROperator{<:CachedOperator{T,<:BandedMatrix{T},
                                        MM,DS,RS,BI}},
                      ::Colon,col) where {T<:BlasFloat,MM,DS,RS,BI}
-    if col ≤ QR.ncols
+    if col ≤ QR.ncols
         return QR
     end
 

--- a/src/Caching/blockbanded.jl
+++ b/src/Caching/blockbanded.jl
@@ -141,7 +141,7 @@ QROperator(R::CachedOperator{T,BlockBandedMatrix{T}}) where {T} =
 # function resizedata!(QR::QROperator{CachedOperator{T,BlockBandedMatrix{T},
 #                                           MM,DS,RS,BI}},
 #                      ::Colon, col) where {T,MM,DS,RS,BI}
-#     if col ≤ QR.ncols
+#     if col ≤ QR.ncols
 #         return QR
 #     end
 #
@@ -214,7 +214,7 @@ function resizedata!(QR::QROperator{CachedOperator{T,BlockBandedMatrix{T},
      ds = domainspace(QR)
      col = blockstop(ds, COL)  # last column
 
-     if col ≤ QR.ncols
+     if col ≤ QR.ncols
          return QR
      end
 
@@ -297,8 +297,8 @@ function resizedata!(QR::QROperator{CachedOperator{T,BlockBandedMatrix{T},
                  # TODO: remove these debugging statement
                  # @assert w_j-1 + M ≤ length(W.data)
                  # @assert shft + st*(ξ_2-1) + M ≤ length(R.data)
-                 # @assert 0 ≤ w_j-1
-                 # if ! (0 ≤ shft + st*(ξ_2-1))
+                 # @assert 0 ≤ w_j-1
+                 # if ! (0 ≤ shft + st*(ξ_2-1))
                  #     @show shft, st, ξ_2, l, u
                  #     @show κ, bs.block_starts[K1,J]
                  #     @show K1, J

--- a/src/Caching/matrix.jl
+++ b/src/Caching/matrix.jl
@@ -19,7 +19,7 @@ function resizedata!(B::CachedOperator{T,Matrix{T}},n::Integer,m::Integer) where
         B.data = unsafe_resize!(B.data,:,m)
     end
 
-    if n ≤ B.datasize[1] && m ≤ B.datasize[2]
+    if n ≤ B.datasize[1] && m ≤ B.datasize[2]
         # do nothing
         B
     elseif n ≤ B.datasize[1]
@@ -56,7 +56,7 @@ function mulpars(Ac::Adjoint{T,<:QROperatorQ{QROperator{RR,Matrix{T},T},T}},
 
     k=1
     yp=view(Y,1:M)
-    while (k ≤ m+M || norm(yp) > tolerance )
+    while (k ≤ m+M || norm(yp) > tolerance )
         if k > maxlength
             @warn "Maximum length $maxlength reached."
             break
@@ -119,7 +119,7 @@ function mulpars(Ac::Adjoint{T,<:QROperatorQ{QROperator{RR,Matrix{T},T},T}},
 
     k=1
     yp=y
-    while (k ≤ min(m+M,A_dim) || BLAS.nrm2(M,yp,1) > tolerance )
+    while (k ≤ min(m+M,A_dim) || BLAS.nrm2(M,yp,1) > tolerance )
         if k > maxlength
             @warn "Maximum length $maxlength reached."
             break

--- a/src/Caching/ragged.jl
+++ b/src/Caching/ragged.jl
@@ -32,7 +32,7 @@ function resizedata!(B::CachedOperator{T,RaggedMatrix{T}},::Colon,n::Integer) wh
         end
 
         # avoid padding with negative length
-        if B.data.cols[n+1] ≤ 0
+        if B.data.cols[n+1] ≤ 0
             return B
         end
 

--- a/src/Domains/Domains.jl
+++ b/src/Domains/Domains.jl
@@ -50,10 +50,10 @@ function _affine_setdiff(d::Domain, p::Number)
     isempty(d) && return d
     p ∉ d  && return d
     a,b = endpoints(d)
-    if leftendpoint(d) > rightendpoint(d)
+    if leftendpoint(d) > rightendpoint(d)
         a,b = b,a
     end
-    UnionDomain(a..p, p..b) # TODO: Clopen interval
+    UnionDomain(a..p, p..b) # TODO: Clopen interval
 end
 
 function _affine_setdiff(d::Domain, pts)
@@ -66,7 +66,7 @@ function _affine_setdiff(d::Domain, pts)
     isapprox(db,pts[end];atol=tol) && pop!(pts)
 
     sort!(pts)
-    leftendpoint(d) > rightendpoint(d) && reverse!(pts)
+    leftendpoint(d) > rightendpoint(d) && reverse!(pts)
     filter!(p->p ∈ d,pts)
 
     isempty(pts) && return d

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -66,7 +66,7 @@ end
 function coefficient(f::Fun,kr::AbstractRange)
     b = maximum(kr)
 
-    if b ≤ ncoefficients(f)
+    if b ≤ ncoefficients(f)
         f.coefficients[kr]
     else
         [coefficient(f,k) for k in kr]
@@ -591,7 +591,7 @@ function copy(bc::Broadcasted{FunStyle})
 end
 
 function copyto!(dest::Fun, bc::Broadcasted{FunStyle})
-    if broadcastdomain(bc) ≠ domain(dest)
+    if broadcastdomain(bc) ≠ domain(dest)
         throw(ArgumentError("Domain of right-hand side incompatible with destination"))
     end
     ret = copy(bc)

--- a/src/LinearAlgebra/RaggedMatrix.jl
+++ b/src/LinearAlgebra/RaggedMatrix.jl
@@ -14,9 +14,9 @@ mutable struct RaggedMatrix{T} <: AbstractMatrix{T}
         # make sure the cols are monitonically increasing
         @assert 1==cols[1]
         for j=1:length(cols)-1
-            @assert cols[j] ≤ cols[j+1]
+            @assert cols[j] ≤ cols[j+1]
         end
-        @assert cols[end] == length(data)+1
+        @assert cols[end] == length(data)+1
 
         # make sure we have less entries than the size of the matrix
         @assert length(data) ≤ m*(length(cols)-1)
@@ -58,7 +58,7 @@ function Base.setindex!(A::RaggedMatrix,v,k::Int,j::Int)
 
     if A.cols[j]+k-1 < A.cols[j+1]
         A.data[A.cols[j]+k-1]=v
-    elseif v ≠ 0
+    elseif v ≠ 0
         throw(BoundsError(A,(k,j)))
     end
     v
@@ -115,7 +115,7 @@ for (op,bop) in ((:(Base.rand), :rrand),)
 end
 
 function RaggedMatrix{T}(Z::Zeros, colns::AbstractVector{Int}) where {T}
-    if size(Z,2) ≠ length(colns)
+    if size(Z,2) ≠ length(colns)
         throw(DimensionMismatch())
     end
     RaggedMatrix(zeros(T,sum(colns)), [1; (1 .+cumsum(colns))], size(Z,1))
@@ -137,7 +137,7 @@ RaggedMatrix(A::AbstractMatrix, colns::AbstractVector{Int}) = RaggedMatrix{eltyp
 function mul!(y::Vector, A::RaggedMatrix, b::Vector)
     m=size(A,2)
 
-    if m ≠ length(b) || size(A,1) ≠ length(y)
+    if m ≠ length(b) || size(A,1) ≠ length(y)
         throw(BoundsError())
     end
     T=eltype(y)
@@ -151,7 +151,7 @@ end
 
 
 function BLAS.axpy!(a, X::RaggedMatrix, Y::RaggedMatrix)
-    if size(X) ≠ size(Y)
+    if size(X) ≠ size(Y)
         throw(BoundsError())
     end
 
@@ -181,7 +181,7 @@ colstop(X::SubArray{T,2,RaggedMatrix{T},Tuple{UnitRange{Int},UnitRange{Int}}},
 
 function BLAS.axpy!(a,X::RaggedMatrix,
                     Y::SubArray{T,2,RaggedMatrix{T},Tuple{UnitRange{Int},UnitRange{Int}}}) where T
-    if size(X) ≠ size(Y)
+    if size(X) ≠ size(Y)
         throw(BoundsError())
     end
 
@@ -194,7 +194,7 @@ function BLAS.axpy!(a,X::RaggedMatrix,
         cy=colstop(Y,j)
         if cx > cy
             for k=cy+1:cx
-                if X[k,j] ≠ 0
+                if X[k,j] ≠ 0
                     throw(BoundsError("Trying to add a non-zero to a zero."))
                 end
             end
@@ -239,7 +239,7 @@ function mul!(Y::RaggedMatrix,A::RaggedMatrix,B::RaggedMatrix)
             col = max(col,colstop(A,k))
         end
 
-        if col > colstop(Y,j)
+        if col > colstop(Y,j)
             throw(BoundsError())
         end
     end

--- a/src/LinearAlgebra/clenshaw.jl
+++ b/src/LinearAlgebra/clenshaw.jl
@@ -285,7 +285,7 @@ function chebmult_getindex(cfs::AbstractVector,k::Integer,j::Integer)
     end
 
     # Hankel part
-    if k ≥ 2 && k+j-1 ≤ n
+    if k ≥ 2 && k+j-1 ≤ n
         ret += cfs[k+j-1]/2
     end
 

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -110,7 +110,7 @@ scal!(n::Integer,cst::BlasFloat,ret::DenseArray{T},k::Integer) where {T<:BlasFlo
     BLAS.scal!(n,convert(T,cst),ret,k)
 
 function scal!(n::Integer,cst::Number,ret::AbstractArray,k::Integer)
-    @assert k*n ≤ length(ret)
+    @assert k*n ≤ length(ret)
     @simd for j=1:k:k*(n-1)+1
         @inbounds ret[j] *= cst
     end

--- a/src/LinearAlgebra/standardchop.jl
+++ b/src/LinearAlgebra/standardchop.jl
@@ -90,7 +90,7 @@ function standardchoplength(coeffs, tol)
     # included to bias the result towards the left end, is minimal.
     #
 
-    if  plateauPoint ≠ 0 && envelope[plateauPoint] == 0
+    if  plateauPoint ≠ 0 && envelope[plateauPoint] == 0
         return plateauPoint
     end
 

--- a/src/Multivariate/Multivariate.jl
+++ b/src/Multivariate/Multivariate.jl
@@ -87,7 +87,7 @@ function Base.kron(f::Fun,g::Fun)
         # the (N+M)th diagonal we have no more entries
         if k+j > N+M
             break
-        elseif k ≤ N && j ≤ M
+        elseif k ≤ N && j ≤ M
             push!(cfs,f.coefficients[k]*g.coefficients[j])
         else
             push!(cfs,0)

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -59,7 +59,7 @@ function next(a::Tensorizer{Tuple{AA,BB}}, ((K,J), (k,j), (rsh,csh), (n,m), (i,t
 end
 
 
-done(a::Tensorizer, ((K,J), (k,j), (rsh,csh), (n,m), (i,tot))) = i ≥ tot
+done(a::Tensorizer, ((K,J), (k,j), (rsh,csh), (n,m), (i,tot))) = i ≥ tot
 
 iterate(a::Tensorizer) = next(a, start(a))
 function iterate(a::Tensorizer, st)
@@ -442,7 +442,7 @@ function totensor(it::Tensorizer,M::AbstractVector)
                         sum(it.blocks[2][1:min(B.n[1],length(it.blocks[2]))]))
     k=1
     for (K,J) in it
-        if k > n
+        if k > n
             break
         end
         ret[K,J] = M[k]

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -283,7 +283,7 @@ function bandedblockbanded_colstart(A::Operator, i::Integer)
 end
 
 function bandedblockbanded_colstop(A::Operator, i::Integer)
-    i ≤ 0 && return 0
+    i ≤ 0 && return 0
     ds = domainspace(A)
     rs = rangespace(A)
     B = block(ds,i)
@@ -744,7 +744,7 @@ for TYP in (:RaggedMatrix, :Matrix)
 end
 
 function Vector(S::Operator)
-    if size(S,2) ≠ 1  || isinf(size(S,1))
+    if size(S,2) ≠ 1  || isinf(size(S,1))
         error("Cannot convert $S to a AbstractVector")
     end
 

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -19,8 +19,8 @@ checkbounds(A::Operator,kr,jr) =
 
 
 checkbounds(A::Operator,K::Block,J::Block) =
-     1 ≤ first(K.n[1]) ≤ length(blocklengths(rangespace(A))) &&
-     1 ≤ first(J.n[1]) ≤ length(blocklengths(domainspace(A)))
+     1 ≤ first(K.n[1]) ≤ length(blocklengths(rangespace(A))) &&
+     1 ≤ first(J.n[1]) ≤ length(blocklengths(domainspace(A)))
 
 checkbounds(A::Operator,K::BlockRange{1},J::BlockRange{1}) =
     isempty(K) || isempty(J) ||
@@ -175,7 +175,7 @@ function colstop(S::SubOperator{T,OP,Tuple{UnitRange{Int},UnitRange{Int}}},j::In
     n = size(S,1)
     if cs < first(kr)
         0
-    elseif cs ≥ last(kr)
+    elseif cs ≥ last(kr)
         n
     else
         min(n,findfirst(isequal(cs),kr))

--- a/src/Operators/general/CachedOperator.jl
+++ b/src/Operators/general/CachedOperator.jl
@@ -73,7 +73,7 @@ blockbandwidths(C::CachedOperator{T,BM,M}) where {T<:Number,BM<:BandedMatrix,M<:
 
 @propagate_inbounds function Base.getindex(B::CachedOperator,k::Integer,j::Integer)
     resizedata!(B,k,j)
-    if k ≤ size(B.data,1) && j ≤ size(B.data,2)
+    if k ≤ size(B.data,1) && j ≤ size(B.data,2)
         B.data[k,j]
     else
         zero(eltype(B))

--- a/src/Operators/general/FiniteOperator.jl
+++ b/src/Operators/general/FiniteOperator.jl
@@ -29,7 +29,7 @@ domainspace(F::FiniteOperator) = F.domainspace
 rangespace(F::FiniteOperator) = F.rangespace
 
 function getindex(F::FiniteOperator,k::Integer,j::Integer)
-    if k ≤ size(F.matrix,1) && j ≤ size(F.matrix,2)
+    if k ≤ size(F.matrix,1) && j ≤ size(F.matrix,2)
         F.matrix[k,j]
     elseif k ≤ size(F,1) && j ≤ size(F,2)
         zero(eltype(F))
@@ -50,8 +50,8 @@ end
 
 function BandedMatrix(S::SubOperator{T,FiniteOperator{AT,T}}) where {AT<:BandedMatrix,T}
     kr,jr=parentindices(S)
-    if last(kr[1]) ≤ size(S.matrix,1) &&
-        last(jr[2]) ≤ size(S.matrix,2)
+    if last(kr[1]) ≤ size(S.matrix,1) &&
+        last(jr[2]) ≤ size(S.matrix,2)
         matrix[kr,jr]
     else
         default_copy(S)

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -383,7 +383,7 @@ for TYP in (:Matrix, :BandedMatrix, :RaggedMatrix)
         P = parent(V)
 
         if isbanded(P)
-            if $TYP ≠ BandedMatrix
+            if $TYP ≠ BandedMatrix
                 return $TYP(BandedMatrix(V))
             end
         elseif isbandedblockbanded(P)

--- a/src/Operators/nullspace.jl
+++ b/src/Operators/nullspace.jl
@@ -41,7 +41,7 @@ function transpose_nullspace(QR::QROperator,tolerance,maxlength)
         QQ=(Matrix(I,m,m)-2v*v')
         K[:,:]=K*QQ[1:end-1,2:end]
 
-        if k+m-1 > size(K,1)
+        if k+m-1 > size(K,1)
             K=pad(K,k+m+100,:)
         end
         K[k+m-1,:]=QQ[end,2:end]

--- a/src/Operators/qr.jl
+++ b/src/Operators/qr.jl
@@ -85,7 +85,7 @@ size(Q::Adjoint{<:Any,<:QROperatorQ}) = (size(parent(Q),2), size(parent(Q),1))
 
 function qr!(A::CachedOperator; cached::Int=0)
     QR = QROperator(A)
-    if cached ≠ 0
+    if cached ≠ 0
         resizedata!(QR,:,cached)
     end
     QR

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -85,9 +85,9 @@ end
 function rowstart(A::KroneckerOperator,k::Integer)
     K=block(rangespace(A),k)
     K2 = Int(K)-blockbandwidth(A,1)
-    K2 ≤ 1 && return 1
+    K2 ≤ 1 && return 1
     ds = domainspace(A)
-    K2 ≥ blocksize(ds,1) && return size(A,2)
+    K2 ≥ blocksize(ds,1) && return size(A,2)
     blockstart(ds,K2)
 end
 
@@ -95,7 +95,7 @@ function rowstop(A::KroneckerOperator,k::Integer)
     K=block(rangespace(A),k)
     ds = domainspace(A)
     K2 = Int(K)+blockbandwidth(A,2)
-    K2 ≥ blocksize(ds) && return size(A,2)
+    K2 ≥ blocksize(ds) && return size(A,2)
     st=blockstop(ds,K2)
     # zero indicates above dimension
     st==0 ? size(A,2) : min(size(A,2),st)

--- a/src/Spaces/ArraySpace.jl
+++ b/src/Spaces/ArraySpace.jl
@@ -142,7 +142,7 @@ end
 
 
 function Fun(v::AbstractVector,sp::Space{D,R}) where {D,R<:AbstractVector}
-    if size(v) ≠ size(sp)
+    if size(v) ≠ size(sp)
         throw(DimensionMismatch("Cannot convert $v to a Fun in space $sp"))
     end
     Fun(map(Fun,v,components(sp)))
@@ -198,7 +198,7 @@ Base.diff(f::Fun{AS,T},n...) where {AS<:ArraySpace,T} = Fun(diff(Array(f),n...))
 ## conversion
 
 function coefficients(f::AbstractVector, a::VectorSpace, b::VectorSpace)
-    if size(a) ≠ size(b)
+    if size(a) ≠ size(b)
         throw(DimensionMismatch("dimensions must match"))
     end
     interlace(map(coefficients,Fun(a,f),b),b)
@@ -279,14 +279,14 @@ ArraySpace(sp::TensorSpace{Tuple{S1,S2}},k...) where {S1,S2<:Space{D,R}} where {
     ArraySpace(map(a -> sp.spaces[1] ⊗ a, sp.spaces[2]))
 
 function coefficients(f::AbstractVector, a::VectorSpace, b::TensorSpace{Tuple{S1,S2},<:EuclideanDomain{2}}) where {S1<:Space{D,R},S2} where {D,R<:AbstractArray}
-    if size(a) ≠ size(b)
+    if size(a) ≠ size(b)
         throw(DimensionMismatch("dimensions must match"))
     end
     interlace(map(coefficients,Fun(a,f),b),ArraySpace(b))
 end
 
 function coefficients(f::AbstractVector, a::VectorSpace, b::TensorSpace{Tuple{S1,S2},<:EuclideanDomain{2}}) where {S1,S2<:Space{D,R}} where {D,R<:AbstractArray}
-    if size(a) ≠ size(b)
+    if size(a) ≠ size(b)
         throw(DimensionMismatch("dimensions must match"))
     end
     interlace(map(coefficients,Fun(a,f),b),ArraySpace(b))

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -5,7 +5,7 @@ iterate(::Fun{SequenceSpace}) = 1
 iterate(f::Fun{SequenceSpace}, st) = f[st], st+1
 
 getindex(f::Fun{SequenceSpace}, k::Integer) =
-    k ≤ ncoefficients(f) ? f.coefficients[k] : zero(cfstype(f))
+    k ≤ ncoefficients(f) ? f.coefficients[k] : zero(cfstype(f))
 getindex(f::Fun{SequenceSpace},K::CartesianIndex{0}) = f[1]
 getindex(f::Fun{SequenceSpace},K) = cfstype(f)[f[k] for k in K]
 
@@ -125,7 +125,7 @@ function getindex(C::ConcreteConversion{CS,S,T},k::Integer,j::Integer) where {CS
         throw(BoundsError())
     end
     on=ones(rangespace(C))
-    k ≤ ncoefficients(on) ? convert(T,on.coefficients[k]) : zero(T)
+    k ≤ ncoefficients(on) ? convert(T,on.coefficients[k]) : zero(T)
 end
 
 

--- a/src/Spaces/HeavisideSpace.jl
+++ b/src/Spaces/HeavisideSpace.jl
@@ -23,7 +23,7 @@ spacescompatible(a::SplineSpace{λ},b::SplineSpace{λ}) where {λ} = domainscomp
 function evaluate(c::AbstractVector{T}, s::HeavisideSpace{<:Real}, x::Real) where T
     p = domain(s).points
     for k=1:length(c)
-        if p[k] ≤ x ≤ p[k+1]
+        if p[k] ≤ x ≤ p[k+1]
             return c[k]
         end
     end
@@ -35,7 +35,7 @@ function evaluate(c::AbstractVector{T}, s::SplineSpace{1,<:Real}, x::Real) where
     p = domain(f).points
     c = f.coefficients
     for k=1:length(p)-1
-        if p[k] ≤ x ≤ p[k+1]
+        if p[k] ≤ x ≤ p[k+1]
             return (x-p[k])*c[k+1]/(p[k+1]-p[k]) + (p[k+1]-x)*c[k]/(p[k+1]-p[k])
         end
     end

--- a/src/Spaces/ProductSpaceOperators.jl
+++ b/src/Spaces/ProductSpaceOperators.jl
@@ -187,7 +187,7 @@ for (OPrule,OP) in ((:conversion_rule,:conversion_type),(:maxspace_rule,:maxspac
             if length(S1) != length(S2)
                 NoSpace()
             elseif canonicalspace(S1sp) == canonicalspace(S2sp)  # this sorts S1 and S2
-                S1sp ≤ S2sp ? S1sp : S2sp  # choose smallest space by sorting
+                S1sp ≤ S2sp ? S1sp : S2sp  # choose smallest space by sorting
             elseif cs1 == cs2
                 # we can just map down
                 # $TYP(map($OP,S1.spaces,S2.spaces))

--- a/src/Spaces/SumSpace.jl
+++ b/src/Spaces/SumSpace.jl
@@ -479,7 +479,7 @@ union_rule(P::PiecewiseSpace,C::ConstantSpace{AnyDomain}) =
 
 ## Multiplication
 function *(f::Fun{<:PiecewiseSpace,T},g::Fun{<:PiecewiseSpace,N}) where {T,N}
-    domain(f) ≠ domain(g) && return default_mult(f,g)
+    domain(f) ≠ domain(g) && return default_mult(f,g)
 
     Fun(map(*,components(f),components(g)),PiecewiseSpace)
 end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -60,7 +60,7 @@ end
 function default_Fun(f,d::Space{ReComp},n::Integer,::Type{Val{true}}) where ReComp
     pts=points(d, n)
     f1=f(pts[1]...)
-    if isa(f1,AbstractArray) && size(d) ≠ size(f1)
+    if isa(f1,AbstractArray) && size(d) ≠ size(f1)
         return Fun(f,Space(fill(d,size(f1))),n)
     end
 

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -5,7 +5,7 @@ function split(d::IntervalOrSegment, pts)
     a,b = endpoints(d)
     isendpoint = true
     for p in pts
-        if !(p ≈ a) && !(p ≈ b)
+        if !(p ≈ a) && !(p ≈ b)
             isendpoint = false
             break
         end
@@ -414,11 +414,11 @@ for SP in (:ConstantSpace,:PointSpace)
     for OP in (:^,)
         @eval begin
             function $OP(z::Fun{<:$SP},k::Integer)
-                k ≠ 0 && return Fun(space(z),$OP.(coefficients(z),k))
+                k ≠ 0 && return Fun(space(z),$OP.(coefficients(z),k))
                 Fun(space(z),$OP.(pad(coefficients(z),dimension(space(z))),k))
             end
             function $OP(z::Fun{<:$SP},k::Number)
-                k ≠ 0 && return Fun(space(z),$OP.(coefficients(z),k))
+                k ≠ 0 && return Fun(space(z),$OP.(coefficients(z),k))
                 Fun(space(z),$OP.(pad(coefficients(z),dimension(space(z))),k))
             end
         end


### PR DESCRIPTION
Minor stylistic change to replace non-breaking spaces with regular ones. Non-breaking spaces show up as Unicode codes in some text editors, and they may be replaced by regular spaces without any change in functionality. An example of the change, and the way it's displayed in sublime text:
![Selection_001](https://user-images.githubusercontent.com/10461665/179498908-a1caeb6d-b823-48cb-a07c-a2ec8e720b6b.png)
Only white spaces are changed in this PR. I used
```console
find src -type f -name "*.jl" -print0 | xargs -0 sed -i '' -e 's/\xc2\xa0/ /g'
```
to perform a recursive find-replace.