### PR TITLE
Avoid splatting in operator sum and multiplication

### DIFF
--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -54,13 +54,9 @@ function convert(::Type{Operator{T}},P::PlusOperator) where T
 end
 
 function promoteplus(opsin::Vector{Operator{T}}) where T
-    ops=Vector{Operator{T}}()
+    ops = copy(opsin)
     # prune zero ops
-    for op in opsin
-        if !iszeroop(op)
-            push!(ops,op)
-        end
-    end
+    filter!(!iszeroop, ops)
     PlusOperator(promotespaces(ops))
 end
 

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -72,16 +72,16 @@ domain(P::PlusOperator) = commondomain(P.ops)
 
 
 +(A::PlusOperator,B::PlusOperator) =
-    promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A.ops...,B.ops...])
+    promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A.ops; B.ops])
 +(A::PlusOperator,B::PlusOperator,C::PlusOperator) =
-    promoteplus(Operator{promote_type(eltype(A),eltype(B),eltype(C))}[A.ops...,B.ops...,C.ops...])
+    promoteplus(Operator{promote_type(eltype(A),eltype(B),eltype(C))}[A.ops; B.ops; C.ops])
 +(A::PlusOperator,B::Operator) =
-    promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A.ops...,B])
+    promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A.ops; B])
 +(A::PlusOperator,B::ZeroOperator) = A
 +(A::PlusOperator,B::Operator,C::Operator) =
-    promoteplus(Operator{promote_type(eltype(A),eltype(B),eltype(C))}[A.ops...,B,C])
+    promoteplus(Operator{promote_type(eltype(A),eltype(B),eltype(C))}[A.ops; B; C])
 +(A::Operator,B::PlusOperator) =
-    promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A,B.ops...])
+    promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A; B.ops])
 +(A::ZeroOperator,B::PlusOperator) = B
 +(A::Operator,B::Operator) =
     promoteplus(Operator{promote_type(eltype(A),eltype(B))}[A,B])
@@ -255,11 +255,11 @@ TimesOperator(ops::Vector{OT}) where {OT<:Operator} =
     TimesOperator(convert(Vector{Operator{eltype(OT)}},ops),bandwidthssum(ops))
 
 TimesOperator(A::TimesOperator,B::TimesOperator) =
-    TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A.ops...,B.ops...])
+    TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A.ops; B.ops])
 TimesOperator(A::TimesOperator,B::Operator) =
-    TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A.ops...,B])
+    TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A.ops; B])
 TimesOperator(A::Operator,B::TimesOperator) =
-    TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A,B.ops...])
+    TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A; B.ops])
 TimesOperator(A::Operator,B::Operator) =
     TimesOperator(Operator{promote_type(eltype(A),eltype(B))}[A,B])
 
@@ -270,7 +270,7 @@ function convert(::Type{Operator{T}},P::TimesOperator) where T
     if T==eltype(P)
         P
     else
-        TimesOperator(Operator{T}[P.ops...])
+        TimesOperator(Operator{T}[P.ops;])
     end
 end
 
@@ -490,19 +490,19 @@ for OP in (:(adjoint),:(transpose))
 end
 
 *(A::TimesOperator,B::TimesOperator) =
-    promotetimes(Operator{promote_type(eltype(A),eltype(B))}[A.ops...,B.ops...])
+    promotetimes(Operator{promote_type(eltype(A),eltype(B))}[A.ops; B.ops])
 function *(A::TimesOperator,B::Operator)
     if isconstop(B)
         promotedomainspace(convert(Number,B)*A,domainspace(B))
     else
-        promotetimes(Operator{promote_type(eltype(A),eltype(B))}[A.ops...,B])
+        promotetimes(Operator{promote_type(eltype(A),eltype(B))}[A.ops; B])
     end
 end
 function *(A::Operator,B::TimesOperator)
     if isconstop(A)
         promoterangespace(convert(Number,A)*B,rangespace(A))
     else
-        promotetimes(Operator{promote_type(eltype(A),eltype(B))}[A,B.ops...])
+        promotetimes(Operator{promote_type(eltype(A),eltype(B))}[A; B.ops])
     end
 end
 function *(A::Operator,B::Operator)


### PR DESCRIPTION
This provides a minor performance boost, as typed concatenation is type-stable, whereas splatting isn't.
```julia
julia> d = Derivative();

julia> @btime reduce(+, fill($d, 100));
  5.354 ms (16399 allocations: 512.64 KiB) # master
  5.210 ms (16039 allocations: 428.41 KiB) # PR
```
The idea is
```julia
julia> f(a,b) = Operator{eltype(a)}[a.ops..., b.ops...]
f (generic function with 1 method)

julia> g(a,b) = Operator{eltype(a)}[a.ops; b.ops]
g (generic function with 1 method)

julia> A = reduce(+, fill(d, 100));

julia> f(A, A) == g(A, A)
true

julia> @btime f($A, $A);
  4.192 μs (1 allocation: 1.77 KiB)

julia> @btime g($A, $A);
  294.360 ns (1 allocation: 1.77 KiB)
```