### PR TITLE
Improve `PlusOperator` performance

### DIFF
--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -39,12 +39,9 @@ end
 
 function PlusOperator(ops::Vector)
     # calculate bandwidths
-    b1,b2=-720,-720  # approximates ∞,-∞
-    for op in ops
-        br=bandwidths(op)
-        b1=max(br[1],b1)
-        b2=max(br[end],b2)
-    end
+    almostneginf=-720  # approximates -∞
+    b1 = mapreduce(first ∘ bandwidths, max, ops, init = almostneginf)
+    b2 = mapreduce(last ∘ bandwidths, max, ops, init = almostneginf)
     PlusOperator(ops,(b1,b2))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,23 @@ end
             end
         end
     end
+    @testset "plus operator" begin
+        c = [1,2,3]
+        f = Fun(PointSpace(1:3), c)
+        M = Multiplication(f)
+        @testset for t in [1, 3]
+            op = M + t * M
+            @test bandwidths(op) == bandwidths(M)
+            @test coefficients(op * f) == @. (1+t)*c^2
+            for op2 in Any[M + M + t * M, op + M]
+                @test bandwidths(op2) == bandwidths(M)
+                @test coefficients(op2 * f) == @. (2+t)*c^2
+            end
+            op3 = op + op
+            @test bandwidths(op3) == bandwidths(M)
+            @test coefficients(op3 * f) == @. 2(1+t)*c^2
+        end
+    end
 end
 
 @time include("ETDRK4Test.jl")


### PR DESCRIPTION
Splitting into function calls helps with performance for badly inferred code.
On master
```julia
julia> d = Derivative(Chebyshev());

julia> @btime reduce(+, fill($d, 100));
  5.437 ms (41644 allocations: 989.08 KiB)
```
This PR
```julia
julia> @btime reduce(+, fill($d, 100));
  1.895 ms (36793 allocations: 834.39 KiB)
```