### PR TITLE
Fix bug in `TimesOperator` constructor, and add Multiplication equality

### DIFF
--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -26,6 +26,8 @@ function ConcreteMultiplication(f::Fun{D,T},sp::Space) where {D,T}
     ConcreteMultiplication{D,typeof(sp),V}(convert(Fun{D,V},chop(f,40*eps(cfstype(f)))),sp)
 end
 
+==(A::ConcreteMultiplication, B::ConcreteMultiplication) = (A.f == B.f) && (A.space == B.space)
+
 # We do this in two stages to support Modifier spaces
 # without ambiguity errors
 function defaultMultiplication(f::Fun,sp::Space)

--- a/src/Operators/general/FiniteOperator.jl
+++ b/src/Operators/general/FiniteOperator.jl
@@ -19,6 +19,7 @@ FiniteOperator(M::AbstractMatrix{<:Number}) =
 convert(::Type{Operator{T}},F::FiniteOperator) where {T} =
     FiniteOperator(convert(AbstractMatrix{T},F.matrix),F.domainspace,F.rangespace)::Operator{T}
 
+==(A::FiniteOperator, B::FiniteOperator) = A.matrix == B.matrix && A.domainspace == B.domainspace && A.rangespace == B.rangespace
 
 Base.promote_rule(::Type{OT},::Type{MT}) where {OT<:Operator,MT<:AbstractMatrix} = Operator{promote_type(eltype(OT),eltype(MT))}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,4 +82,36 @@ end
     @test ApproxFunBase.coefficients(f) === v
 end
 
+@testset "operator algebra" begin
+    @testset "Multiplication" begin
+        sp = PointSpace(1:3)
+        coeff = [1:3;]
+        f = Fun(sp, coeff)
+        for sp2 in Any[(), (sp,)]
+            a = Multiplication(f, sp2...)
+            b = Multiplication(f, sp2...)
+            @test a == b
+            @test bandwidths(a) == bandwidths(b)
+        end
+    end
+    @testset "TimesOperator" begin
+        sp = PointSpace(1:3)
+        coeff = [1:3;]
+        f = Fun(sp, coeff)
+        for sp2 in Any[(), (sp,)]
+            M = Multiplication(f, sp2...)
+            a = (M * M) * M
+            b = M * (M * M)
+            @test a == b
+            @test bandwidths(a) == bandwidths(b)
+        end
+        @testset "unwrap TimesOperator" begin
+            M = Multiplication(f)
+            for ops in Any[Operator{Float64}[M, M * M], Operator{Float64}[M*M, M]]
+                @test TimesOperator(ops).ops == [M, M, M]
+            end
+        end
+    end
+end
+
 @time include("ETDRK4Test.jl")


### PR DESCRIPTION
This fixes an associativity bug. On master,
```julia
julia> M = Multiplication(Fun());

julia> @btime $M * $M;
  2.207 μs (10 allocations: 304 bytes)

julia> TimesOperator([M*M, M]) # this fails
ERROR: MethodError: no method matching Vector{Operator{Float64}}(::Int64)

julia> TimesOperator([M, M*M]) # this works
TimesOperator : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> M1 = Multiplication(Fun());

julia> M2 = Multiplication(Fun());

julia> M1 == M2
false
```
This PR
```julia
julia> @btime $M * $M;
  1.368 μs (16 allocations: 528 bytes)

julia> TimesOperator([M*M, M])
TimesOperator : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> M1 == M2
true
```