### PR TITLE
Improve inference in `Fun * Operator`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -36,7 +36,7 @@ domain(A::Operator) = domain(domainspace(A))
 
 isconstspace(_) = false
 ## Functionals
-isafunctional(A::Operator) = size(A,1)==1 && isconstspace(rangespace(A))
+isafunctional(A::Operator)::Bool = size(A,1)==1 && isconstspace(rangespace(A))
 
 
 isonesvec(A) = A isa AbstractFill && getindex_value(A) == 1

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -30,6 +30,10 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
         A = @inferred f * Multiplication(f)
         @test A * f == f^3
 
+        @testset "inafunctional inference" begin
+            @test @inferred !ApproxFunBase.isafunctional(Multiplication(f))
+        end
+
         @testset "real/complex coefficients" begin
             c = [1:4;]
             for c2 in Any[c, c*im]

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -27,6 +27,9 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
             @test (@inferred oftype(f, fany)) isa typeof(f)
         end
 
+        A = @inferred f * Multiplication(f)
+        @test A * f == f^3
+
         @testset "real/complex coefficients" begin
             c = [1:4;]
             for c2 in Any[c, c*im]


### PR DESCRIPTION
After this, the following is inferred:
```julia
julia> @inferred Fun() * Derivative()
TimesOperator : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()
```