### PR TITLE
Specialize `literal_pow` for `Fun`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -369,11 +369,11 @@ end
 
 ^(f::Fun, k::Integer) = intpow(f,k)
 # some common cases
-Base.literal_pow(f::typeof(^), x::Fun, ::Val{0}) = ones(space(x))
-Base.literal_pow(f::typeof(^), x::Fun, ::Val{1}) = x
-Base.literal_pow(f::typeof(^), x::Fun, ::Val{2}) = x * x
-Base.literal_pow(f::typeof(^), x::Fun, ::Val{3}) = x * x * x
-Base.literal_pow(f::typeof(^), x::Fun, ::Val{4}) = x * x * x * x
+Base.literal_pow(::typeof(^), x::Fun, ::Val{0}) = ones(cfstype(x), space(x))
+Base.literal_pow(::typeof(^), x::Fun, ::Val{1}) = x
+Base.literal_pow(::typeof(^), x::Fun, ::Val{2}) = x * x
+Base.literal_pow(::typeof(^), x::Fun, ::Val{3}) = x * x * x
+Base.literal_pow(::typeof(^), x::Fun, ::Val{4}) = x * x * x * x
 
 inv(f::Fun) = 1/f
 

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -368,6 +368,12 @@ function intpow(f::Fun,k::Integer)
 end
 
 ^(f::Fun, k::Integer) = intpow(f,k)
+# some common cases
+Base.literal_pow(f::typeof(^), x::Fun, ::Val{0}) = ones(space(x))
+Base.literal_pow(f::typeof(^), x::Fun, ::Val{1}) = x
+Base.literal_pow(f::typeof(^), x::Fun, ::Val{2}) = x * x
+Base.literal_pow(f::typeof(^), x::Fun, ::Val{3}) = x * x * x
+Base.literal_pow(f::typeof(^), x::Fun, ::Val{4}) = x * x * x * x
 
 inv(f::Fun) = 1/f
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -102,6 +102,14 @@ using ApproxFunOrthogonalPolynomials
             @test (@inferred (x -> x^2)(f)) == ApproxFunBase.intpow(f,2)
             @test (@inferred (x -> x^3)(f)) == ApproxFunBase.intpow(f,3)
             @test (@inferred (x -> x^4)(f)) == ApproxFunBase.intpow(f,4)
+
+            local f = Fun(PointSpace(Float32[1:3;]), Float32[1:3;])
+            g = @inferred (x -> x^0)(f)
+            @test eltype(coefficients(g)) == Float32
+            g = @inferred (x -> x^1)(f)
+            @test eltype(coefficients(g)) == Float32
+            g = @inferred (x -> x^2)(f)
+            @test eltype(coefficients(g)) == Float32
         end
     end
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -94,6 +94,15 @@ using ApproxFunOrthogonalPolynomials
         M2 = M + M
         infty = ApproxFunBase.InfiniteCardinal{0}()
         @test (@inferred size(M2)) == (infty, infty)
+
+        @testset "literal pow" begin
+            local f = Fun(PointSpace(1:3), Float64[1:3;])
+            @test (@inferred (x -> x^0)(f)) == ApproxFunBase.intpow(f,0)
+            @test (@inferred (x -> x^1)(f)) == ApproxFunBase.intpow(f,1)
+            @test (@inferred (x -> x^2)(f)) == ApproxFunBase.intpow(f,2)
+            @test (@inferred (x -> x^3)(f)) == ApproxFunBase.intpow(f,3)
+            @test (@inferred (x -> x^4)(f)) == ApproxFunBase.intpow(f,4)
+        end
     end
 
     @testset "Derivative operator for HeavisideSpace" begin


### PR DESCRIPTION
This helps with inference in some common cases
On master
```julia
julia> @inferred (x -> x^2)(Fun())
ERROR: return type Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}} does not match inferred return type Any
```
This PR
```julia
julia> @inferred (x -> x^2)(Fun())
Fun(Chebyshev(),[0.5, 0.0, 0.5])
```