### PR TITLE
Restore QR on old julia versions

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        julia-version: [1]
+        julia-version: [1, 1.6]
         os: [ubuntu-latest]
         package:
           - {repo: ApproxFun.jl, group: JuliaApproximation}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.12"
+version = "0.5.13"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/nullspace.jl
+++ b/src/Operators/nullspace.jl
@@ -1,9 +1,13 @@
 
-
+if VERSION >= v"1.7"
+    _qrcolnorm(K) = qr(K, ColumnNorm())
+else
+    _qrcolnorm(K) = qr(K, Val(true))
+end
 function nullspace(A::Operator{T};tolerance=10eps(real(T)),maxlength=1_000_000) where T
-   K=transpose_nullspace(qr(A'),tolerance,maxlength)
+    K=transpose_nullspace(qr(A'),tolerance,maxlength)
     # drop extra rows, and use QR to determine rank
-    Q,R = qr(K, ColumnNorm())
+    Q,R = _qrcolnorm(K)
     ind=findfirst(r->abs(r)≤100tolerance,diag(R))
     Kret=ind==0 ? Q : Q[:,1:ind-1]
     Fun(Space(fill(domainspace(A),(1,ind-1))),vec(Kret'))


### PR DESCRIPTION
Also add downstream test on `v1.6`, which should cover this change.