### PR TITLE
Relax 3-argument Fun constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -71,7 +71,7 @@ end
 
 default_Fun(f,d::Space{ReComp},n::Integer) where {ReComp} = default_Fun(f,d,n,Val{!hasnumargs(f,1)})
 
-Fun(f::Function,d::Space{ReComp},n::Integer) where {ReComp} = default_Fun(dynamic(f),d,n)
+Fun(f,d::Space{ReComp},n::Integer) where {ReComp} = default_Fun(dynamic(f),d,n)
 
 # the following is to avoid ambiguity
 # Fun(f::Fun,d) should be equivalent to Fun(x->f(x),d)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -50,6 +50,14 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
             end
             @test ApproxFunBase.intpow(f,-2) == f^-2 == 1/(f*f)
         end
+
+        @testset "Fun accepts callables" begin
+            struct Foo end
+            (::Foo)(x) = x
+            f1 = Fun(Foo(), PointSpace(1:10))
+            f2 = Fun(Foo(), PointSpace(1:10), 10)
+            @test coefficients(f1) == coefficients(f2)
+        end
     end
 
     @testset "Derivative operator for HeavisideSpace" begin


### PR DESCRIPTION
The 2-argument constructor had earlier been relaxed to accept general callable types. This PR relaxes the 3-argument constructor. After this, something like this works:
```julia
julia> struct Foo end

julia> (::Foo)(x) = rand()

julia> Fun(Foo(), Chebyshev());
```