### PR TITLE
Type stability in promote spaces

### DIFF
--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -9,7 +9,7 @@ export domainspace,rangespace
 abstract type Operator{T} end #T is the entry type, Float64 or Complex{Float64}
 
 eltype(::Operator{T}) where {T} = T
-eltype(::Type{Operator{T}}) where {T} = T
+eltype(::Type{<:Operator{T}}) where {T} = T
 eltype(::Type{OT}) where {OT<:Operator} = eltype(supertype(OT))
 
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -131,4 +131,14 @@ import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, V
         f = Fun(2)
         @test (@inferred convert(Fun{typeof(space(f))}, 2)) == f
     end
+
+    @testset "promotion" begin
+        M = Multiplication(Fun(PointSpace(1:3), [1:3;]));
+        D = Derivative()
+        for v in Any[[M, M], [D, D], [D, M]]
+            @test (@inferred ApproxFunBase.promotedomainspace(v)) == v
+            @test (@inferred ApproxFunBase.promoterangespace(v)) == v
+            @test (@inferred ApproxFunBase.promotespaces(v)) == v
+        end
+    end
 end


### PR DESCRIPTION
After this, the following is type stable:
```julia
julia> M = Multiplication(Fun(PointSpace(1:3), [1:3;]));

julia> v = [M, M];

julia> @inferred ApproxFunBase.promotespaces(v);
```