### PR TITLE
remove unnecessary conversion to Any

### DIFF
--- a/src/Operators/banded/Conversion.jl
+++ b/src/Operators/banded/Conversion.jl
@@ -26,7 +26,7 @@ rangespace(C::ConcreteConversion)=C.rangespace
 
 
 
-function defaultConversion(a::Space,b::Space)::Any
+function defaultConversion(a::Space,b::Space)
     if a==b
         Conversion(a)
     elseif conversion_type(a,b)==NoSpace()

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -122,7 +122,7 @@ choosedomainspace(A::Operator,_) = choosedomainspace(A)
 
 choosedomainspace(A) = choosedomainspace(A,UnsetSpace())
 
-function choosedomainspace(ops::AbstractVector,spin)::Any
+function choosedomainspace(ops::AbstractVector,spin)
     sp = UnsetSpace()
 
     for op in ops

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -153,7 +153,7 @@ mappoint(a::Domain,b::Space,x)=mappoint(a,domain(b),x)
 
 for FUNC in (:conversion_rule,:maxspace_rule,:union_rule)
     @eval begin
-        function $FUNC(a,b)::Any
+        function $FUNC(a,b)
             if spacescompatible(a,b)
                 a
             else
@@ -175,7 +175,7 @@ end
 
 
 # gives a space c that has a banded conversion operator TO a and b
-function conversion_type(a,b)::Any
+function conversion_type(a,b)
     if spacescompatible(a,b)
         a
     elseif !domainscompatible(a,b)
@@ -194,7 +194,7 @@ end
 
 # gives a space c that has a banded conversion operator FROM a and b
 maxspace(a,b) = NoSpace()  # TODO: this fixes weird bug with Nothing
-function maxspace(a::Space, b::Space)::Any
+function maxspace(a::Space, b::Space)
     if spacescompatible(a,b)
         return a
     elseif !domainscompatible(a,b)
@@ -254,7 +254,7 @@ union(a::AmbiguousSpace, b::Space) = b
 union(a::Space, b::AmbiguousSpace) = a
 
 
-function union_by_union_rule(a::Space,b::Space)::Any
+function union_by_union_rule(a::Space,b::Space)
     if spacescompatible(a,b)
         if isambiguous(domain(a))
             return b
@@ -269,7 +269,7 @@ function union_by_union_rule(a::Space,b::Space)::Any
     union_rule(b,a)
 end
 
-function union(a::Space, b::Space)::Any
+function union(a::Space, b::Space)
     cr = union_by_union_rule(a,b)
     cr isa NoSpace || return cr
 

--- a/src/Spaces/ProductSpaceOperators.jl
+++ b/src/Spaces/ProductSpaceOperators.jl
@@ -5,14 +5,14 @@ export continuity
 
 for TYP in (:PiecewiseSpace,:ArraySpace)
     @eval begin
-        function promotedomainspace(A::InterlaceOperator{T,2},sp::$TYP)::Any where T
+        function promotedomainspace(A::InterlaceOperator{T,2},sp::$TYP) where T
             if domainspace(A) == sp
                 return A
             end
             @assert size(A.ops,2) == length(sp)
             InterlaceOperator([promotedomainspace(A.ops[k,j],sp[j]) for k=1:size(A.ops,1),j=1:size(A.ops,2)],$TYP)
         end
-        function interlace_choosedomainspace(ops,rs::$TYP)::Any
+        function interlace_choosedomainspace(ops,rs::$TYP)
             @assert length(ops) == length(rs)
             # this ensures correct dispatch for unino
             sps = Array{Space}(
@@ -93,7 +93,7 @@ end
 
 # Sum Space and PiecewiseSpace need to allow permutation of space orders
 for TYP in (:SumSpace,:PiecewiseSpace)
-    @eval function Conversion(S1::$TYP,S2::$TYP)::Any
+    @eval function Conversion(S1::$TYP,S2::$TYP)
         v1 = collect(S1.spaces)
         v2 = collect(S2.spaces)
 
@@ -180,7 +180,7 @@ end
 for (OPrule,OP) in ((:conversion_rule,:conversion_type),(:maxspace_rule,:maxspace),
                         (:union_rule,:union))
     for TYP in (:SumSpace,:PiecewiseSpace)
-        @eval function $OPrule(S1sp::$TYP,S2sp::$TYP)::Any
+        @eval function $OPrule(S1sp::$TYP,S2sp::$TYP)
             S1 = components(S1sp)
             S2 = components(S2sp)
             cs1,cs2=map(canonicalspace,S1),map(canonicalspace,S2)
@@ -239,7 +239,7 @@ for (Op,OpWrap) in ((:Derivative,:DerivativeWrapper),(:Integral,:IntegralWrapper
     end
 end
 
-function Derivative(S::SumSpace,k::Integer)::Any
+function Derivative(S::SumSpace,k::Integer)
     # we want to map before we decompose, as the map may introduce
     # mixed bases.
     if typeof(canonicaldomain(S))==typeof(domain(S))

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -8,7 +8,7 @@ include("SubSpace.jl")
 include("QuotientSpace.jl")
 
 
-⊕(A::Space,B::Space)::Any = domainscompatible(A,B) ? SumSpace(A,B) : PiecewiseSpace(A,B)
+⊕(A::Space,B::Space) = domainscompatible(A,B) ? SumSpace(A,B) : PiecewiseSpace(A,B)
 ⊕(f::Fun,g::Fun) = Fun(space(f) ⊕ space(g), interlace(coefficients(f),coefficients(g)))
 
 ⊕(f::Fun,g::Fun,h::Fun...) = ⊕((f ⊕ g), h...)

--- a/src/Spaces/SumSpace.jl
+++ b/src/Spaces/SumSpace.jl
@@ -182,7 +182,7 @@ end
 
 
 # avoids default ConstantSpace
-function union_rule(B::ConstantSpace,A::SumSpace)::Any
+function union_rule(B::ConstantSpace,A::SumSpace)
     if !domainscompatible(A,B)
         NoSpace()
     else
@@ -195,7 +195,7 @@ function union_rule(B::ConstantSpace,A::SumSpace)::Any
     end
 end
 
-function union_rule(A::SumSpace, B::Space)::Any
+function union_rule(A::SumSpace, B::Space)
     if !domainscompatible(A,B)
         NoSpace()
     else


### PR DESCRIPTION
Type assertions to functions add an extra conversion at the end. Since conversion to `Any` is a no-op, this make no difference to the result. For example,
```julia
julia> f(x)::Any = x
f (generic function with 1 method)

julia> @code_typed f(2)
CodeInfo(
1 ─     return x
) => Int64
```
We may therefore remove the `::Any` type assertions on functions 