### PR TITLE
`UnsetSpace` compatibility with other spaces

### DIFF
--- a/src/Space.jl
+++ b/src/Space.jl
@@ -114,6 +114,8 @@ canonicaldomain(S::Space) = canonicaldomain(domain(S))
 # This is used in place of == to support AnyDomain
 spacescompatible(f::D,g::D) where D<:Space = error("Override spacescompatible for "*string(D))
 spacescompatible(::UnsetSpace,::UnsetSpace) = true
+spacescompatible(::Space, ::UnsetSpace) = true
+spacescompatible(::UnsetSpace, ::Space) = true
 spacescompatible(::NoSpace,::NoSpace) = true
 spacescompatible(f,g) = false
 ==(A::Space,B::Space) = spacescompatible(A,B) && domain(A) == domain(B)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -173,5 +173,10 @@ using ApproxFunOrthogonalPolynomials
         v = rand(4)
         v2 = transform(NormalizedChebyshev(), v)
         @test itransform(NormalizedChebyshev(), v2) ≈ v
+
+        @testset "ApproxFun.jl issue 616" begin
+            x, D = Fun(), Derivative(Chebyshev())
+            @test (D*Multiplication(x)*D)*x ≈ 1
+        end
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaApproximation/ApproxFun.jl/issues/616
```julia
julia> I = Interval(0,1); x = Fun(identity, I); ∂ = Derivative(I);

julia> ∂ * Multiplication(x)
TimesOperator : ApproxFunBase.UnsetSpace() → Ultraspherical(1,0..1)

julia> ∂ * Multiplication(x) : Chebyshev(I)
TimesOperator : Chebyshev(0..1) → Ultraspherical(1,0..1)
 1.0  1.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   1.0  2.0  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   1.5  3.0  1.5   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   2.0  4.0  2.0   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   2.5  5.0  2.5   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   3.0  6.0  3.0   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   3.5  7.0  3.5   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   4.0  8.0  4.0  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   4.5  9.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   5.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱

julia> ∂ * Multiplication(x) * Fun(Legendre(I)) ≈ 2x
true
```