### PR TITLE
despecialize union, split default_mult

### DIFF
--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -243,7 +243,7 @@ extrapolate(f::Fun,x,y,z...) = extrapolate(f.coefficients,f.space,Vec(x,y,z...))
 
 values(f::Fun,dat...) = itransform(f.space,f.coefficients,dat...)
 points(f::Fun) = points(f.space,ncoefficients(f))
-ncoefficients(f::Fun) = length(f.coefficients)
+ncoefficients(f::Fun)::Int = length(f.coefficients)
 blocksize(f::Fun) = (block(space(f),ncoefficients(f)).n[1],)
 
 function stride(f::Fun)

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -41,15 +41,13 @@ hasnumargs(f::Fun,k) = k == 1 || domaindimension(f) == k  # all funs take a sing
 ##Coefficient routines
 #TODO: domainscompatible?
 
-_coefficients(fc::Vector, sp, msp) = oftype(fc, coefficients(fc, sp, msp))::typeof(fc)
-_coefficients(fc, sp, msp) = coefficients(fc, sp, msp)
 function coefficients(f::Fun,msp::Space)
     #zero can always be converted
     fc = f.coefficients
     if ncoefficients(f) == 0 || (ncoefficients(f) == 1 && fc[1] == 0)
         fc
     else
-        _coefficients(fc, space(f), msp)
+        coefficients(fc, space(f), msp)
     end
 end
 coefficients(f::Fun,::Type{T}) where {T<:Space} = coefficients(f,T(domain(f)))

--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -135,7 +135,7 @@ function default_mult(f::Fun,g::Fun)
     if domainscompatible(space(f),space(g))
         default_mult_compatible(f, g)
     else
-        sp=union(space(f),space(g))
+        sp=union(space(f),space(g))::Space
         fnew = Fun(f,sp)
         gnew = Fun(g,sp)
         default_mult_compatible(fnew, gnew)
@@ -146,16 +146,16 @@ end
 
 coefficienttimes(f::Fun,g::Fun) = Multiplication(f,space(g))*g
 
-function transformtimes(f::Fun,g::Fun,n)
-    @assert pointscompatible(space(f),space(g))
-    isempty(f.coefficients) && return f
-    isempty(g.coefficients) && return g
-    f2,g2,sp = pad(f,n),pad(g,n),space(f)
-    hc = transform(sp,values(f2).*values(g2))
+function transformtimes(f::Fun,g::Fun, n = ncoefficients(f) + ncoefficients(g) - 1, sp = space(f))
+    @assert pointscompatible(sp,space(g))::Bool
+    iszero(ncoefficients(f)) && return f
+    iszero(ncoefficients(g)) && return g
+    f2,g2 = pad(f,n), pad(g,n)
+    v = values(f2)
+    v .*= values(g2)
+    hc = transform(sp, v)
     chop!(Fun(sp,hc),10eps(eltype(hc)))
 end
-transformtimes(f::Fun,g::Fun) = transformtimes(f,g,ncoefficients(f) + ncoefficients(g) - 1)
-
 
 
 *(a::Fun,L::UniformScaling) = Multiplication(a*L.λ,UnsetSpace())

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -266,13 +266,12 @@ function union(@nospecialize(a::Space), @nospecialize(b::Space))
     cspa=canonicalspace(a)
     cspb=canonicalspace(b)
     if cspa!=a || cspb!=b
-        cr = union_by_union_rule(cspa,cspb)
+        crc = union_by_union_rule(cspa,cspb)
+        crc isa NoSpace || return crc
     end
     # TODO: Uncomment when Julia bug is fixed
-    cr=maxspace(a,b)  #Max space since we can convert both to it
-    if !isa(cr,NoSpace)
-        return cr
-    end
+    cr2=maxspace(a,b)  #Max space since we can convert both to it
+    cr2 isa NoSpace || return cr2
 
     a ⊕ b
 end

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -244,7 +244,7 @@ union_by_union_rule(a::AmbiguousSpace, b::Space) = b
 union_by_union_rule(a::Space, b::AmbiguousSpace) = a
 
 
-function union_by_union_rule(a::Space,b::Space)
+function union_by_union_rule(@nospecialize(a::Space), @nospecialize(b::Space))
     if spacescompatible(a,b)
         if isambiguous(domain(a))
             return b
@@ -259,7 +259,7 @@ function union_by_union_rule(a::Space,b::Space)
     union_rule(b,a)
 end
 
-function union(a::Space, b::Space)
+function union(@nospecialize(a::Space), @nospecialize(b::Space))
     cr = union_by_union_rule(a,b)
     cr isa NoSpace || return cr
 

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -34,7 +34,7 @@ function testtransforms(S::Space;minpoints=1,invertibletransform=true)
 end
 
 function testcalculus(S::Space;haslineintegral=true,hasintegral=true)
-    for k=1:min(5,dimension(S))
+    @testset for k=1:min(5,dimension(S))
         v = [zeros(k-1);1.0]
         f = Fun(S,v)
         @test abs(DefiniteIntegral()*f-sum(f)) < 100eps()
@@ -51,7 +51,7 @@ function testcalculus(S::Space;haslineintegral=true,hasintegral=true)
 end
 
 function testmultiplication(spa,spb)
-    for k=1:10
+    @testset for k=1:10
         a = Fun(spa,[zeros(k-1);1.])
         M = Multiplication(a,spb)
         pts = ApproxFunBase.checkpoints(rangespace(M))

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -12,7 +12,7 @@ using ApproxFunOrthogonalPolynomials
         a = @inferred Fun(exp, space(f))
         @test f/a == @inferred Fun(x->(x-0.1)*exp(-x),space(f))
 
-        f = Fun(space(f),[1.,2.,3.])
+        f = @inferred Fun(space(f),[1.,2.,3.])
 
         @test (+f) == f
 
@@ -169,12 +169,13 @@ using ApproxFunOrthogonalPolynomials
         end
     end
 
-    @testset "AmbiguousSpace" begin
+    @testset "union and AmbiguousSpace" begin
         a = PointSpace(1:3)
+        @test (@inferred union(a, a)) == a
         for b in Any[ApproxFunBase.UnsetSpace(), ApproxFunBase.NoSpace()]
-            @test union(a, b) == a
-            @test union(b, a) == a
-            @test union(b, b) == b
+            @test (@inferred union(a, b)) == a
+            @test (@inferred union(b, a)) == a
+            @test (@inferred union(b, b)) == b
         end
     end
 
@@ -183,7 +184,7 @@ using ApproxFunOrthogonalPolynomials
         v2 = transform(NormalizedChebyshev(), v)
         @test itransform(NormalizedChebyshev(), v2) ≈ v
 
-        f = Fun(x->x^2, Chebyshev())
+        f = @inferred Fun(x->x^2, Chebyshev())
         v = coefficients(f, Chebyshev(), Legendre())
         @test v ≈ coefficients(Fun(x->x^2, Legendre()))
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -234,11 +234,11 @@ using ApproxFunOrthogonalPolynomials
             f = Fun(Chebyshev(0..1))
             newfc(f) = coefficients(Fun(Fun(f, Legendre(0..1)), space(f)))
             newvals(f) = values(Fun(Fun(f, Legendre(0..1)), space(f)))
-            @test @inferred(newfc(f)) ≈ coefficients(f)
-            @test @inferred(newvals(f)) ≈ values(f)
+            @test newfc(f) ≈ coefficients(f)
+            @test newvals(f) ≈ values(f)
 
             newfc2(f) = coefficients(chop(pad(f, 10)))
-            @test @inferred(newfc2(f)) == coefficients(f)
+            @test newfc2(f) == coefficients(f)
 
             f2 = Fun(space(f), view(Float64[1:4;], :))
             f3 = Fun(space(f), Float64[1:4;])

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -218,5 +218,10 @@ using ApproxFunOrthogonalPolynomials
                     Conversion(Chebyshev(), Ultraspherical(1))
             @test Matrix(C12[1:10, 1:10]) ≈ Matrix(C1C2[1:10, 1:10])
         end
+
+        @testset "union" begin
+            @test union(Chebyshev(), NormalizedLegendre()) == Jacobi(Chebyshev())
+            @test union(Chebyshev(), Legendre()) == Jacobi(Chebyshev())
+        end
     end
 end


### PR DESCRIPTION
This improves TTFX somewhat:
master
```julia
julia> f = Fun(Chebyshev(0..1));

julia> @time union(space(f), space(f))
  2.642244 seconds (4.15 M allocations: 255.851 MiB, 12.97% gc time, 100.00% compilation time)
Chebyshev(0..1)
```
PR
```julia
julia> @time union(space(f), space(f))
  0.066540 seconds (157.41 k allocations: 9.111 MiB, 99.42% compilation time)
Chebyshev(0..1)
```
This isn't really representative of a real use case, though, but I'm trying to look into how to improve badly inferred code paths.

Also split `default_mult` into components to avoid recursion.
Finally, reduce proliferation of type parameters to avoid over specialization.