### PR TITLE
improve inference in `Fun()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -20,7 +20,7 @@ end
 const VFun{S,T} = Fun{S,T,Vector{T}}
 
 Fun(sp::Space,coeff::AbstractVector) = Fun{typeof(sp),eltype(coeff),typeof(coeff)}(sp,coeff)
-Fun() = Fun(identity)
+Fun() = Fun(identity, ChebyshevInterval())
 Fun(d::Domain) = Fun(identity,d)
 Fun(d::Space) = Fun(identity,d)
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -183,6 +183,8 @@ using ApproxFunOrthogonalPolynomials
     end
 
     @testset "ApproxFunOrthogonalPolynomials" begin
+        @test (@inferred Fun()) == Fun(x->x, Chebyshev())
+
         v = rand(4)
         v2 = transform(NormalizedChebyshev(), v)
         @test itransform(NormalizedChebyshev(), v2) ≈ v


### PR DESCRIPTION
It seems `Fun()` was not being type-inferred. Fixed now.
```julia
julia> @inferred Fun()
Fun(Chebyshev(), [0.0, 1.0])
```