### PR TITLE
Improved inference in `coefficients`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -72,6 +72,9 @@ end
 coefficient(f::Fun,K::Block) = coefficient(f,blockrange(space(f),K.n[1]))
 coefficient(f::Fun,::Colon) = coefficient(f,1:dimension(space(f)))
 
+# convert to vector while computing coefficients
+_maybeconvert(inplace::Val{false}, f::Fun, v) = strictconvert(Vector{cfstype(f)}, v)
+
 ##Convert routines
 
 

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -50,6 +50,7 @@ function isapprox_atol(x::AbstractArray{T}, y::AbstractArray{S},atol::Real=0; rt
 end
 
 # The second case handles zero
+isapproxinteger(::Integer) = true
 isapproxinteger(x) = isapprox(x,round(Int,x))  || isapprox(x+1,round(Int,x+1))
 
 

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -309,10 +309,12 @@ _ldiv_coefficients!!(inplace::Val{false}) = ldiv_coefficients
 
 _Fun(v::AbstractVector, sp) = Fun(sp, v)
 _Fun(v, sp) = Fun(v, sp)
+_maybeconvert(inplace::Val{true}, f, v) = v
+_maybeconvert(inplace::Val{false}, f::AbstractVector, v) = strictconvert(Vector{eltype(f)}, v)
 function defaultcoefficients(f,a,b,inplace = Val(false))
     ct=conversion_type(a,b) # gives a space that has a banded conversion to both a and b
 
-    if spacescompatible(a,b)
+    x = if spacescompatible(a,b)
         f
     elseif hasconversion(a,b)
         _mul_coefficients!!(inplace)(Conversion(a,b),f)
@@ -331,6 +333,7 @@ function defaultcoefficients(f,a,b,inplace = Val(false))
             _coefficients!!(inplace)(f,a,csp,b)
         end
     end
+    _maybeconvert(inplace, f, x)
 end
 
 coefficients(f,a,b) = defaultcoefficients(f,a,b)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -225,8 +225,13 @@ using ApproxFunOrthogonalPolynomials
         @test itransform(NormalizedChebyshev(), v2) ≈ v
 
         f = @inferred Fun(x->x^2, Chebyshev())
-        v = coefficients(f, Chebyshev(), Legendre())
+        v = @inferred coefficients(f, Chebyshev(), Legendre())
+        @test eltype(v) == eltype(coefficients(f))
         @test v ≈ coefficients(Fun(x->x^2, Legendre()))
+
+        # inference check for coefficients
+        v = @inferred coefficients(Float64[0,0,1], Chebyshev(), Ultraspherical(1))
+        @test v ≈ [-0.5, 0, 0.5]
 
         @testset "inplace transform" begin
             @testset for sp_c in Any[Legendre(), Chebyshev(), Jacobi(1,2), Jacobi(0.3, 2.3),


### PR DESCRIPTION
Ideally, this shouldn't be necessary, but currently inference fails in the various branches in `defaultcoefficients`, so this hack might help with inference downstream. After this PR:
```julia
julia> @inferred coefficients(Float64[1,2,3], Chebyshev(), Ultraspherical(1));
```
