### PR TITLE
improved TTFX in multiplication

### DIFF
--- a/src/LinearAlgebra/standardchop.jl
+++ b/src/LinearAlgebra/standardchop.jl
@@ -57,8 +57,8 @@ function standardchoplength(coeffs, tol)
     # Step 1: Convert COEFFS to a new monotonically nonincreasing
     #         vector ENVELOPE normalized to begin with the value 1.
 
-    b = abs.(coeffs)
-    m = b[end]*fill(1.0,n)
+    b = map(abs, coeffs)
+    m = fill(b[end]*1.0, n)
     for j = n-1:-1:1
         m[j] = max(b[j], m[j+1]);
     end
@@ -94,13 +94,16 @@ function standardchoplength(coeffs, tol)
         return plateauPoint
     end
 
-    j3 = sum(envelope .≥ tol^(7/6))
+    j3 = count(≥(tol^(7/6)), envelope)
     if j3 < j2
         j2 = j3 + 1
         envelope[j2] = tol^(7/6)
     end
-    cc = log10.(envelope[1:j2])
-    cc .+= range(0, stop=(-1/3)*log10(tol), length=j2)
+    cc = map(log10, @view envelope[1:j2])
+    rng = range(0, stop=(-1/3)*log10(tol), length=j2)
+    for (i,ri) in enumerate(rng)
+        cc[i] += ri
+    end
     d = argmin(cc)
     return max(d - 1, 1)
 end


### PR DESCRIPTION
On master
```julia
julia> f1 = Fun()
Fun(Chebyshev(), [0.0, 1.0])

julia> @time M1 = Multiplication(f1)
  1.115510 seconds (1.94 M allocations: 101.535 MiB, 31.87% gc time, 99.95% compilation time)
ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> @time M1 * M1
  0.608894 seconds (1.50 M allocations: 87.054 MiB, 6.12% gc time, 99.79% compilation time)
TimesOperator : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> @code_warntype M1 * M1
[...]
  A::ApproxFunBase.ConcreteMultiplication{Chebyshev{ChebyshevInterval{Float64}, Float64}, ApproxFunBase.UnsetSpace, Float64}
  B::ApproxFunBase.ConcreteMultiplication{Chebyshev{ChebyshevInterval{Float64}, Float64}, ApproxFunBase.UnsetSpace, Float64}
Body::Operator{Float64}
```
This PR
```julia
julia> @time M1 = Multiplication(f1)
  0.785952 seconds (1.38 M allocations: 73.887 MiB, 28.81% gc time, 99.93% compilation time)
ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> @time M1 * M1
  0.618498 seconds (1.38 M allocations: 78.924 MiB, 21.18% gc time, 99.83% compilation time)
TimesOperator : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> @code_warntype M1 * M1
[....]
  A::ApproxFunBase.ConcreteMultiplication{Chebyshev{ChebyshevInterval{Float64}, Float64}, ApproxFunBase.UnsetSpace, Float64}
  B::ApproxFunBase.ConcreteMultiplication{Chebyshev{ChebyshevInterval{Float64}, Float64}, ApproxFunBase.UnsetSpace, Float64}
Body::TimesOperator{Float64}
```
The bandwidth of the `TimesOperator` isn't inferred as yet, so the return type isn't concrete.