### PR TITLE
Remove explicit CI test on `v1.8`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         version:
           - '1.5'
           - '1'
-          - '^1.8.0-0'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Now that `v1` points to `v1.8`