### PR TITLE
compact show for operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.6.14"
+version = "0.6.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -25,7 +25,7 @@ import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !, 
                 zeros, zero, one, promote_rule, repeat, length, resize!, isinf,
                 getproperty, findfirst, unsafe_getindex, fld, cld, div, imag,
                 @_inline_meta, eachindex, firstindex, lastindex, keys, isreal, OneTo,
-                Array, Vector, Matrix, view, ones, @propagate_inbounds,
+                Array, Vector, Matrix, view, ones, @propagate_inbounds, print_array,
                 split, iszero, permutedims, rad2deg, deg2rad
 
 import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, broadcastable,

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -25,7 +25,7 @@ import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !, 
                 zeros, zero, one, promote_rule, repeat, length, resize!, isinf,
                 getproperty, findfirst, unsafe_getindex, fld, cld, div, imag,
                 @_inline_meta, eachindex, firstindex, lastindex, keys, isreal, OneTo,
-                Array, Vector, Matrix, view, ones, @propagate_inbounds, print_array,
+                Array, Vector, Matrix, view, ones, @propagate_inbounds,
                 split, iszero, permutedims, rad2deg, deg2rad
 
 import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle, broadcastable,

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -181,12 +181,20 @@ function colstop(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer
         min(n,findfirst(isequal(cs),kr))
     end
 end
-colstart(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer) =
-    max(findfirst(parentindices(S)[1],colstart(parent(S),parentindices(S)[2][j])),1)
-rowstart(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer) =
-    max(1,findfirst(parentindices(S)[2],rowstart(parent(S),parentindices(S)[1][j])))
-rowstop(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer) =
-        findfirst(parentindices(S)[2],rowstop(parent(S),parentindices(S)[1][j]))
+function colstart(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer)
+    cind = colstart(parent(S),parentindices(S)[2][j])
+    ind = findfirst(==(cind), parentindices(S)[1])
+    max(ind,1)
+end
+function rowstart(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer)
+    rind = rowstart(parent(S),parentindices(S)[1][j])
+    ind = findfirst(==(rind), parentindices(S)[2],)
+    max(1,ind)
+end
+function rowstop(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer)
+    ind = rowstop(parent(S),parentindices(S)[1][j])
+    findfirst(==(ind), parentindices(S)[2])
+end
 
 
 # blocks don't change

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -188,7 +188,7 @@ function colstart(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Intege
 end
 function rowstart(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer)
     rind = rowstart(parent(S),parentindices(S)[1][j])
-    ind = findfirst(==(rind), parentindices(S)[2],)
+    ind = findfirst(==(rind), parentindices(S)[2])
     max(1,ind)
 end
 function rowstop(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer)

--- a/src/Operators/general/OperatorLayout.jl
+++ b/src/Operators/general/OperatorLayout.jl
@@ -82,6 +82,7 @@ domain(P::AdjointOperator)=domain(P.op)
 bandwidths(P::AdjointOperator) = reverse(bandwidths(P.op))
 
 getindex(P::AdjointOperator,k::Integer,j::Integer) = conj(P.op[j,k])
+getindex(P::AdjointOperator,inds...) = adjoint(P.op[reverse(inds)...])
 
 function BandedMatrix(S::SubOperator{T,TO}) where {T,TO<:AdjointOperator}
     kr,jr=parentindices(S)

--- a/src/show.jl
+++ b/src/show.jl
@@ -69,7 +69,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
             BM=B[1:10,1:10]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,11,11)
-            for I in CartesianIndices(BM)
+            for I in CartesianIndices(axes(BM))
                 M[I]=BM[Tuple(I)...] # not certain if indexing with CartesianIndex is implemented
             end
 
@@ -89,7 +89,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
             BM=B[1:10,1:sz2int]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,11,sz2int)
-            for I in CartesianIndices(BM)
+            for I in CartesianIndices(axes(BM))
                 M[I]=BM[Tuple(I)...]
             end
             for k=1:sz2int
@@ -102,7 +102,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
             BM=B[1:sz1int,1:10]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,sz1int,11)
-            for I in CartesianIndices(BM)
+            for I in CartesianIndices(axes(BM))
                 M[I]=BM[Tuple(I)...]
             end
             for k=1:sz1int

--- a/src/show.jl
+++ b/src/show.jl
@@ -40,11 +40,9 @@ Base.show(io::IO, N::PrintShow) = print(io, N.c)
 
 show(io::IO, B::Operator; kw...) = summary(io, B)
 
-function show(io::IO, ::MIME"text/plain", @nospecialize(B::Operator); header::Bool=true)
+function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); header::Bool=true)
     header && summary(io, B)
     dsp = domainspace(B)
-
-    iocompact = haskey(io, :compact) ? io : IOContext(io, :compact=>true)
 
     sz1_B, sz2_B = size(B)
 
@@ -66,12 +64,12 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(B::Operator); header::Bo
                 M[end,j]=PrintShow('⋱')
             end
 
-            print_array(iocompact, M)
+            show(io, mimetype, M)
         elseif isinf(sz1_B) && isinf(sz2_B)
             BM=B[1:10,1:10]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,11,11)
-            for I in CartesianIndices((1:10, 1:10))
+            for I in CartesianIndices(BM)
                 M[I]=BM[Tuple(I)...] # not certain if indexing with CartesianIndex is implemented
             end
 
@@ -85,37 +83,37 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(B::Operator); header::Bo
                 M[end,k]=PrintShow('⋱')
             end
 
-            print_array(iocompact, M)
+            show(io, mimetype, M)
         elseif isinf(sz1_B)
             sz2int = Int(sz2_B)::Int
             BM=B[1:10,1:sz2int]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,11,sz2int)
-            for I in CartesianIndices((1:10, 1:10))
+            for I in CartesianIndices(BM)
                 M[I]=BM[Tuple(I)...]
             end
             for k=1:sz2int
                 M[end,k]=PrintShow('⋮')
             end
 
-            print_array(iocompact, M)
+            show(io, mimetype, M)
         elseif isinf(sz2_B)
             sz1int = Int(sz1_B)::Int
             BM=B[1:sz1int,1:10]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,sz1int,11)
-            for I in CartesianIndices((1:10, 1:10))
+            for I in CartesianIndices(BM)
                 M[I]=BM[Tuple(I)...]
             end
             for k=1:sz1int
                 M[k,end]=PrintShow('⋯')
             end
 
-            print_array(iocompact, M)
+            show(io, mimetype, M)
         else
             sz1int = Int(sz1_B)::Int
             sz2int = Int(sz2_B)::Int
-            print_array(iocompact, AbstractMatrix(B)[1:sz1int,1:sz2int])
+            show(io, mimetype, AbstractMatrix(B)[1:sz1int,1:sz2int])
         end
     end
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -40,9 +40,11 @@ Base.show(io::IO, N::PrintShow) = print(io, N.c)
 
 show(io::IO, B::Operator; kw...) = summary(io, B)
 
-function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
+function show(io::IO, ::MIME"text/plain", @nospecialize(B::Operator); header::Bool=true)
     header && summary(io, B)
     dsp = domainspace(B)
+
+    iocompact = haskey(io, :compact) ? io : IOContext(io, :compact=>true)
 
     if !isambiguous(domainspace(B)) && (eltype(B) <: Number)
         println()
@@ -62,7 +64,7 @@ function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
                 M[end,j]=PrintShow('⋱')
             end
 
-            print_array(io, M)
+            print_array(iocompact, M)
         elseif isinf(size(B,1)) && isinf(size(B,2))
             BM=B[1:10,1:10]
 
@@ -78,7 +80,7 @@ function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
                 M[k,end]=M[end,k]=PrintShow('⋱')
             end
 
-            print_array(io, M)
+            print_array(iocompact, M)
         elseif isinf(size(B,1))
             BM=B[1:10,1:size(B,2)]
 
@@ -90,7 +92,7 @@ function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
                 M[end,k]=PrintShow('⋮')
             end
 
-            print_array(io, M)
+            print_array(iocompact, M)
         elseif isinf(size(B,2))
             BM=B[1:size(B,1),1:10]
 
@@ -102,9 +104,9 @@ function show(io::IO, ::MIME"text/plain", B::Operator;header::Bool=true)
                 M[k,end]=PrintShow('⋯')
             end
 
-            print_array(io, M)
+            print_array(iocompact, M)
         else
-            print_array(io, AbstractMatrix(B)[1:size(B,1),1:size(B,2)])
+            print_array(iocompact, AbstractMatrix(B)[1:size(B,1),1:size(B,2)])
         end
     end
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -46,6 +46,8 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
 
     sz1_B, sz2_B = size(B)
 
+    iocompact = haskey(io, :compact) ? io : IOContext(io, :compact => true)
+
     if !isambiguous(domainspace(B)) && (eltype(B) <: Number)
         println(io)
         if isbanded(B) && isinf(sz1_B) && isinf(sz2_B)
@@ -64,7 +66,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
                 M[end,j]=PrintShow('⋱')
             end
 
-            show(io, mimetype, M)
+            print_array(iocompact, M)
         elseif isinf(sz1_B) && isinf(sz2_B)
             BM=B[1:10,1:10]
 
@@ -83,7 +85,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
                 M[end,k]=PrintShow('⋱')
             end
 
-            show(io, mimetype, M)
+            print_array(iocompact, M)
         elseif isinf(sz1_B)
             sz2int = Int(sz2_B)::Int
             BM=B[1:10,1:sz2int]
@@ -96,7 +98,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
                 M[end,k]=PrintShow('⋮')
             end
 
-            show(io, mimetype, M)
+            print_array(iocompact, M)
         elseif isinf(sz2_B)
             sz1int = Int(sz1_B)::Int
             BM=B[1:sz1int,1:10]
@@ -109,11 +111,11 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
                 M[k,end]=PrintShow('⋯')
             end
 
-            show(io, mimetype, M)
+            print_array(iocompact, M)
         else
             sz1int = Int(sz1_B)::Int
             sz2int = Int(sz2_B)::Int
-            show(io, mimetype, AbstractMatrix(B)[1:sz1int,1:sz2int])
+            print_array(iocompact, AbstractMatrix(B)[1:sz1int,1:sz2int])
         end
     end
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -46,9 +46,11 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(B::Operator); header::Bo
 
     iocompact = haskey(io, :compact) ? io : IOContext(io, :compact=>true)
 
+    sz1_B, sz2_B = size(B)
+
     if !isambiguous(domainspace(B)) && (eltype(B) <: Number)
-        println()
-        if isbanded(B) && isinf(size(B,1)) && isinf(size(B,2))
+        println(io)
+        if isbanded(B) && isinf(sz1_B) && isinf(sz2_B)
             BM=B[1:10,1:10]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,11,11)
@@ -65,48 +67,55 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(B::Operator); header::Bo
             end
 
             print_array(iocompact, M)
-        elseif isinf(size(B,1)) && isinf(size(B,2))
+        elseif isinf(sz1_B) && isinf(sz2_B)
             BM=B[1:10,1:10]
 
             M=Matrix{Union{eltype(B), PrintShow}}(undef,11,11)
-            for k=1:10,j=1:10
-                M[k,j]=BM[k,j]
+            for I in CartesianIndices((1:10, 1:10))
+                M[I]=BM[Tuple(I)...] # not certain if indexing with CartesianIndex is implemented
             end
 
             M[1,end]=PrintShow('⋯')
             M[end,1]=PrintShow('⋮')
 
             for k=2:11
-                M[k,end]=M[end,k]=PrintShow('⋱')
+                M[k,end]=PrintShow('⋱')
+            end
+            for k=2:11
+                M[end,k]=PrintShow('⋱')
             end
 
             print_array(iocompact, M)
-        elseif isinf(size(B,1))
-            BM=B[1:10,1:size(B,2)]
+        elseif isinf(sz1_B)
+            sz2int = Int(sz2_B)::Int
+            BM=B[1:10,1:sz2int]
 
-            M=Matrix{Union{eltype(B), PrintShow}}(undef,11,size(B,2))
-            for k=1:10,j=1:size(B,2)
-                M[k,j]=BM[k,j]
+            M=Matrix{Union{eltype(B), PrintShow}}(undef,11,sz2int)
+            for I in CartesianIndices((1:10, 1:10))
+                M[I]=BM[Tuple(I)...]
             end
-            for k=1:size(B,2)
+            for k=1:sz2int
                 M[end,k]=PrintShow('⋮')
             end
 
             print_array(iocompact, M)
-        elseif isinf(size(B,2))
-            BM=B[1:size(B,1),1:10]
+        elseif isinf(sz2_B)
+            sz1int = Int(sz1_B)::Int
+            BM=B[1:sz1int,1:10]
 
-            M=Matrix{Union{eltype(B), PrintShow}}(undef,size(B,1),11)
-            for k=1:size(B,1),j=1:10
-                M[k,j]=BM[k,j]
+            M=Matrix{Union{eltype(B), PrintShow}}(undef,sz1int,11)
+            for I in CartesianIndices((1:10, 1:10))
+                M[I]=BM[Tuple(I)...]
             end
-            for k=1:size(B,1)
+            for k=1:sz1int
                 M[k,end]=PrintShow('⋯')
             end
 
             print_array(iocompact, M)
         else
-            print_array(iocompact, AbstractMatrix(B)[1:size(B,1),1:size(B,2)])
+            sz1int = Int(sz1_B)::Int
+            sz2int = Int(sz2_B)::Int
+            print_array(iocompact, AbstractMatrix(B)[1:sz1int,1:sz2int])
         end
     end
 end

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -2,6 +2,7 @@ using ApproxFunBase, Test
 import ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, Vec, checkpoints
 using ApproxFunOrthogonalPolynomials
 using StaticArrays
+using BandedMatrices: rowrange, colrange
 
 @testset "Spaces" begin
     @testset "PointSpace" begin

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -340,5 +340,12 @@ using StaticArrays
             @test Derivative(Chebyshev()) != Derivative(Chebyshev(), 2)
             @test Derivative(Chebyshev()) != Derivative(Legendre())
         end
+
+        @testset "SubOperator" begin
+            D = Derivative(Chebyshev())
+            S = @view D[1:10, 1:10]
+            @test rowrange(S, 1) == 2:2
+            @test colrange(S, 2) == 1:1
+        end
     end
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -32,22 +32,33 @@
 	@testset "Operator" begin
 		@testset "Derivative" begin
 			D = Derivative()
-			dsum = ApproxFunBase.summarystr(D)
-			@test repr(D) == dsum
+			summarystr = ApproxFunBase.summarystr(D)
+			@test repr(D) == summarystr
 			show(io, MIME"text/plain"(), D)
-			@test contains(String(take!(io)), dsum)
+			@test contains(String(take!(io)), summarystr)
 
 			D = Derivative(Chebyshev())
-			dsum = ApproxFunBase.summarystr(D)
+			summarystr = ApproxFunBase.summarystr(D)
 			show(io, MIME"text/plain"(), D)
-			@test contains(String(take!(io)), dsum)
+			@test contains(String(take!(io)), summarystr)
 		end
 		@testset "SubOperator" begin
 			D = Derivative(Chebyshev())
 			S = @view D[1:10, 1:10]
-			dsum = ApproxFunBase.summarystr(S)
+			summarystr = ApproxFunBase.summarystr(S)
 			show(io, MIME"text/plain"(), S)
-			@test contains(String(take!(io)), dsum)
+			@test contains(String(take!(io)), summarystr)
+		end
+		@testset "Evaluation" begin
+			E = Evaluation(Chebyshev(), 0)
+			summarystr = ApproxFunBase.summarystr(E)
+			show(io, MIME"text/plain"(), E)
+			@test contains(String(take!(io)), summarystr)
+
+			EA = Evaluation(Chebyshev(), 0)'
+			summarystr = ApproxFunBase.summarystr(EA)
+			show(io, MIME"text/plain"(), EA)
+			@test contains(String(take!(io)), summarystr)
 		end
 		@testset "QuotientSpace" begin
 			Q = QuotientSpace(Dirichlet(ConstantSpace(0..1)))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,4 +1,5 @@
 @testset "show" begin
+	io = IOBuffer()
 	@testset "Domain" begin
 		@testset "Segment" begin
 			s = Segment(0, 1)
@@ -33,7 +34,6 @@
 			D = Derivative()
 			dsum = ApproxFunBase.summarystr(D)
 			@test repr(D) == dsum
-			io = IOBuffer()
 			show(io, MIME"text/plain"(), D)
 			@test contains(String(take!(io)), dsum)
 
@@ -52,7 +52,6 @@
 		@testset "QuotientSpace" begin
 			Q = QuotientSpace(Dirichlet(ConstantSpace(0..1)))
 			@test startswith(repr(Q), "ConstantSpace(0..1) /")
-			io = IOBuffer()
 			show(io, MIME"text/plain"(), Q)
 			s = String(take!(io))
 			@test startswith(s, "ConstantSpace(0..1) /")

--- a/test/show.jl
+++ b/test/show.jl
@@ -36,6 +36,18 @@
 			io = IOBuffer()
 			show(io, MIME"text/plain"(), D)
 			@test contains(String(take!(io)), dsum)
+
+			D = Derivative(Chebyshev())
+			dsum = ApproxFunBase.summarystr(D)
+			show(io, MIME"text/plain"(), D)
+			@test contains(String(take!(io)), dsum)
+		end
+		@testset "SubOperator" begin
+			D = Derivative(Chebyshev())
+			S = @view D[1:10, 1:10]
+			dsum = ApproxFunBase.summarystr(S)
+			show(io, MIME"text/plain"(), S)
+			@test contains(String(take!(io)), dsum)
 		end
 		@testset "QuotientSpace" begin
 			Q = QuotientSpace(Dirichlet(ConstantSpace(0..1)))


### PR DESCRIPTION
This makes the display of operators similar to that for matrices.
After this
```julia
julia> Derivative(NormalizedChebyshev())
DerivativeWrapper : NormalizedChebyshev() → Ultraspherical(1)
 ⋅  0.797885   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
 ⋅   ⋅        1.59577   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
 ⋅   ⋅         ⋅       2.39365   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
 ⋅   ⋅         ⋅        ⋅       3.19154   ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
 ⋅   ⋅         ⋅        ⋅        ⋅       3.98942   ⋅        ⋅        ⋅        ⋅       ⋅
 ⋅   ⋅         ⋅        ⋅        ⋅        ⋅       4.78731   ⋅        ⋅        ⋅       ⋅
 ⋅   ⋅         ⋅        ⋅        ⋅        ⋅        ⋅       5.58519   ⋅        ⋅       ⋅
 ⋅   ⋅         ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       6.38308   ⋅       ⋅
 ⋅   ⋅         ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       7.18096  ⋅
 ⋅   ⋅         ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋱
 ⋅   ⋅         ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋱
```
This also makes the display times slightly faster by avoiding specializing on the types of the operators.
On master
```julia
julia> D = Derivative(NormalizedChebyshev());

julia> io = IOBuffer();

julia> @time show(io, MIME("text/plain"), D);

  4.935376 seconds (11.19 M allocations: 564.487 MiB, 5.19% gc time, 99.89% compilation time)

julia> D = Derivative(Chebyshev());

julia> @time show(io, MIME("text/plain"), D);

  0.123173 seconds (500.34 k allocations: 24.599 MiB, 99.54% compilation time)
```
This PR
```julia
julia> using ApproxFun

julia> io = IOBuffer();

julia> D = Derivative(NormalizedChebyshev());

julia> @time show(io, MIME("text/plain"), D);
  4.534671 seconds (10.72 M allocations: 533.026 MiB, 4.54% gc time, 99.81% compilation time)

julia> D = Derivative(Chebyshev());

julia> @time show(io, MIME("text/plain"), D);
  0.029711 seconds (37.16 k allocations: 2.003 MiB, 87.81% compilation time)
```