### PR TITLE
zero with element instead of eltype in pad

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.6.16"
+version = "0.6.17"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -229,13 +229,7 @@ end
 
 function pad(f::AbstractVector, n::Integer)
 	if n > length(f)
-        ret=similar(f, n)
-        ret[1:length(f)]=f
-        z = length(f) > 0 ? zero(f[1]) : zero(eltype(f))
-        for j=length(f)+1:n
-           ret[j] = z
-        end
-        ret
+        pad!(copy(f), n)
 	else
         f[1:n]
 	end

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -216,23 +216,26 @@ function unsafe_resize!(W::AbstractMatrix,n::Integer,m::Integer)
 end
 
 
-function pad!(f::AbstractVector{T},n::Integer) where T
-	if n > length(f)
-		append!(f,zeros(T,n - length(f)))
-	else
-		resize!(f,n)
+function pad!(f::AbstractVector, n::Integer)
+    m = length(f)
+	resize!(f,n)
+	if n > m
+        z = m > 0 ? zero(f[1]) : zero(eltype(f))
+		f[m+1:n] .= z
 	end
+    f
 end
 
 
-function pad(f::AbstractVector{T},n::Integer) where T
+function pad(f::AbstractVector, n::Integer)
 	if n > length(f)
-	   ret=Vector{T}(undef, n)
-	   ret[1:length(f)]=f
-	   for j=length(f)+1:n
-	       ret[j]=zero(T)
-	   end
-       ret
+        ret=similar(f, n)
+        ret[1:length(f)]=f
+        z = length(f) > 0 ? zero(f[1]) : zero(eltype(f))
+        for j=length(f)+1:n
+           ret[j] = z
+        end
+        ret
 	else
         f[1:n]
 	end

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -226,14 +226,7 @@ function pad!(f::AbstractVector, n::Integer)
     f
 end
 
-
-function pad(f::AbstractVector, n::Integer)
-	if n > length(f)
-        pad!(copy(f), n)
-	else
-        f[1:n]
-	end
-end
+pad(f::AbstractVector, n::Integer) = pad!(copy(f), n)
 
 function pad(f::AbstractVector{Any},n::Integer)
 	if n > length(f)

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -221,16 +221,18 @@ function pad!(f::AbstractVector, n::Integer)
 	resize!(f,n)
 	if n > m
         z = m > 0 ? zero(f[1]) : zero(eltype(f))
-		f[m+1:n] .= z
+        for i in m+1:n
+            f[i] = z
+        end
 	end
     f
 end
 
-pad(f::AbstractVector, n::Integer) = pad!(copy(f), n)
+pad(f::AbstractVector, n::Integer) = pad!(Vector(f), n)
 
 function pad(f::AbstractVector{Any},n::Integer)
 	if n > length(f)
-        Any[f...,zeros(n - length(f))...]
+        Any[f; zeros(n - length(f))]
 	else
         f[1:n]
 	end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ApproxFunBase, LinearAlgebra, Random, Test
 import ApproxFunBase: ∞
+using ApproxFunOrthogonalPolynomials
 
 @testset "Helper" begin
     @testset "interlace" begin
@@ -43,13 +44,23 @@ import ApproxFunBase: ∞
         @test_throws MethodError ApproxFunBase.dot(DotTester())
     end
     @testset "pad" begin
-        f = Fun()
-        zf = zero(f)
-        @test (@inferred pad([f], 3)) == [f, zf, zf]
-        @test (@inferred pad([f, zf], 1)) == [f]
-        v = [f, zf]
-        @test @inferred pad!(v, 1) == [f]
-        @test length(v) == 1
+        @testset "float" begin
+            a = rand(3)
+            b = @inferred pad(a, 4)
+            @testset length(b) == 4
+            @test @view(b[1:3]) == a
+            @test b[end] == 0
+            @test pad(a, 2) == @view(a[1:2])
+        end
+        @testset "Fun" begin
+            f = Fun()
+            zf = zero(f)
+            @test (@inferred pad([f], 3)) == [f, zf, zf]
+            @test (@inferred pad([f, zf], 1)) == [f]
+            v = [f, zf]
+            @test @inferred pad!(v, 1) == [f]
+            @test length(v) == 1
+        end
     end
 
     # TODO: Tensorizer tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,12 +45,14 @@ using ApproxFunOrthogonalPolynomials
     end
     @testset "pad" begin
         @testset "float" begin
-            a = rand(3)
-            b = @inferred pad(a, 4)
-            @testset length(b) == 4
-            @test @view(b[1:3]) == a
-            @test b[end] == 0
-            @test pad(a, 2) == @view(a[1:2])
+            @testset for T in [Float64, Any]
+                a = T[1,2,3]
+                b = @inferred pad(a, 4)
+                @testset length(b) == 4
+                @test @view(b[1:3]) == a
+                @test b[end] == 0
+                @test pad(a, 2) == @view(a[1:2])
+            end
         end
         @testset "Fun" begin
             f = Fun()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,15 @@ import ApproxFunBase: ∞
         # check that unknown types don't lead to a stack overflow
         @test_throws MethodError ApproxFunBase.dot(DotTester())
     end
+    @testset "pad" begin
+        f = Fun()
+        zf = zero(f)
+        @test (@inferred pad([f], 3)) == [f, zf, zf]
+        @test (@inferred pad([f, zf], 1)) == [f]
+        v = [f, zf]
+        @test @inferred pad!(v, 1) == [f]
+        @test length(v) == 1
+    end
 
     # TODO: Tensorizer tests
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ using ApproxFunOrthogonalPolynomials
             @testset for T in [Float64, Any]
                 a = T[1,2,3]
                 b = @inferred pad(a, 4)
-                @testset length(b) == 4
+                @test length(b) == 4
                 @test @view(b[1:3]) == a
                 @test b[end] == 0
                 @test pad(a, 2) == @view(a[1:2])


### PR DESCRIPTION
Try `zero` with the element first, which works for a vector of `Fun`s.
```julia
julia> f = Fun()
Fun(Chebyshev(), [0.0, 1.0])

julia> pad([f], 3)
3-element Vector{Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}}:
 Fun(Chebyshev(), [0.0, 1.0])
 Fun(Chebyshev(), [0.0])
 Fun(Chebyshev(), [0.0])
```