### PR TITLE
multiplication of real and complex Fun

### DIFF
--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -151,9 +151,7 @@ function transformtimes(f::Fun,g::Fun, n = ncoefficients(f) + ncoefficients(g) -
     iszero(ncoefficients(f)) && return f
     iszero(ncoefficients(g)) && return g
     f2,g2 = pad(f,n), pad(g,n)
-    v = values(f2)
-    v .*= values(g2)
-    hc = transform(sp, v)
+    hc = transform(sp, values(f2) .* values(g2))
     chop!(Fun(sp,hc),10eps(eltype(hc)))
 end
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -322,6 +322,12 @@ using BandedMatrices: rowrange, colrange, BandedMatrix
             @test values(f2) ≈ values(f3)
         end
 
+        @testset "multiplication of Funs" begin
+            f = Fun(Chebyshev(), Float64[1:101;])
+            g = Fun(Chebyshev(), Float64[1:101;]*im)
+            @test f(0.5)*g(0.5) ≈ (f*g)(0.5)
+        end
+
         @testset "Multivariate" begin
             @testset for S in Any[Chebyshev(), Legendre()]
                 f = Fun(x->ones(2,2), S)


### PR DESCRIPTION
Fixes `f*g` where the `eltype`s aren't convertible without inexact errors, such as real and complex `Fun`s. Now 
```julia
julia> f = Fun(Chebyshev(), Float64[1:101;]);

julia> g = Fun(Chebyshev(), Float64[1:100;]*im);

julia> f(0.5)*g(0.5) ≈ (f*g)(0.5)
true
```