### PR TITLE
store size for plus and times operators

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,6 +203,9 @@ end
             @test T * M == M * T == M * M * M
             @test TT == T * T == M * M * M * M
             @test (@inferred adjoint(T)) == adjoint(M) * adjoint(M)
+
+            M = Multiplication(f, sp)
+            @test M^2 == M * M == (T : sp)
         end
         @testset "plus operator" begin
             c = [1,2,3]


### PR DESCRIPTION
On master
```julia
julia> M = Multiplication(Fun(), Chebyshev())
ConcreteMultiplication : Chebyshev() → Chebyshev()
 0.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 1.0  0.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   0.5  0.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   0.5  0.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   0.5  0.0  0.5   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   0.5  0.0  0.5   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   0.5  0.0  0.5   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5  0.0  0.5   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5  0.0  0.5  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋱   ⋱

julia> @code_typed size(M + M)
CodeInfo(
1 ─ %1 = invoke ApproxFunBase._size(A::PlusOperator{Float64, Tuple{Int64, Int64}}, 1::Int64)::Any
│   %2 = invoke ApproxFunBase._size(A::PlusOperator{Float64, Tuple{Int64, Int64}}, 2::Int64)::Any
│   %3 = Core.tuple(%1, %2)::Tuple{Any, Any}
└──      return %3
) => Tuple{Any, Any}
```
This PR
```julia
julia> @code_typed size(M + M)
CodeInfo(
1 ─     return (ℵ₀, ℵ₀)
) => Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}
```
This should help with type inference