### PR TITLE
bugfix in `ldiv_coefficients`

### DIFF
--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -381,5 +381,14 @@ using BandedMatrices: rowrange, colrange, BandedMatrix
             @test colrange(S, 2) == 1:1
             @test (@inferred BandedMatrix(S)) == (@inferred Matrix(S))
         end
+
+        @testset "inplace ldiv" begin
+            @testset for T in [Float32, Float64, ComplexF32, ComplexF64]
+                v = rand(T, 4)
+                v2 = copy(v)
+                ApproxFunBase.ldiv_coefficients!(Conversion(Chebyshev(), Ultraspherical(1)), v)
+                @test ApproxFunBase.ldiv_coefficients(Conversion(Chebyshev(), Ultraspherical(1)), v2) ≈ v
+            end
+        end
     end
 end


### PR DESCRIPTION
Adds the missing `ldiv_coefficients!(::Operator, ::AbstractVector)` method by converting the operator to the `eltype` of the vector, and fixes `ldiv_coefficients(::Operator{<:Real}, ::AbstractVector{<:Complex})`.

On master
```julia
julia> v = rand(ComplexF32, 4);

julia> ApproxFunBase.ldiv_coefficients(Conversion(Chebyshev(), Ultraspherical(1)), v)
4-element Vector{ComplexF64}:
 1.1584808230400085 + NaN*im
 1.2104620933532715 + NaN*im
  1.744177222251892 + NaN*im
 0.6986570358276367 + NaN*im

julia> ApproxFunBase.ldiv_coefficients!(Conversion(Chebyshev(), Ultraspherical(1)), copy(v))
ERROR: StackOverflowError
```
This PR
```julia
julia> ApproxFunBase.ldiv_coefficients(Conversion(Chebyshev(), Ultraspherical(1)), v)
4-element Vector{ComplexF64}:
 1.1584808230400085 + 1.8255538940429688im
 1.2104620933532715 + 3.066184639930725im
  1.744177222251892 + 1.8943266868591309im
 0.6986570358276367 + 1.5452032089233398im

julia> ApproxFunBase.ldiv_coefficients!(Conversion(Chebyshev(), Ultraspherical(1)), copy(v))
4-element Vector{ComplexF32}:
  1.1584809f0 + 1.8255539f0im
  1.2104621f0 + 3.0661845f0im
  1.7441772f0 + 1.8943267f0im
 0.69865704f0 + 1.5452032f0im
```