### PR TITLE
Fix `similar` for `RaggedMatrix`

### DIFF
--- a/src/LinearAlgebra/RaggedMatrix.jl
+++ b/src/LinearAlgebra/RaggedMatrix.jl
@@ -104,7 +104,7 @@ convert(::Type{RaggedMatrix}, B::AbstractMatrix) = RaggedMatrix{eltype(B)}(B)
 RaggedMatrix(B::AbstractMatrix) = strictconvert(RaggedMatrix, B)
 RaggedMatrix{T}(B::AbstractMatrix) where T = strictconvert(RaggedMatrix{T}, B)
 
-Base.similar(B::RaggedMatrix,::Type{T}) where {T} = RaggedMatrix(Vector{T}(length(B.data)),copy(B.cols),B.m)
+Base.similar(B::RaggedMatrix,::Type{T}) where {T} = RaggedMatrix(similar(B.data, T),copy(B.cols),B.m)
 
 for (op,bop) in ((:(Base.rand), :rrand),)
     @eval begin

--- a/test/MatrixTest.jl
+++ b/test/MatrixTest.jl
@@ -17,4 +17,13 @@ using ApproxFunBase, Test
     @test Matrix(B) == Matrix(ApproxFunBase.RaggedMatrix(B))
     @test ApproxFunBase.RaggedMatrix(B) == ApproxFunBase.RaggedMatrix{Float64}(B)
     @test ApproxFunBase.RaggedMatrix(ApproxFunBase.BandedMatrix{ComplexF64}(B)) == ApproxFunBase.RaggedMatrix{ComplexF64}(B)
+
+    @testset "similar" begin
+        B = ApproxFunBase.brand(10,10,2,3)
+        R = ApproxFunBase.RaggedMatrix(B)
+        S = similar(R, ComplexF64)
+        @test S isa ApproxFunBase.RaggedMatrix
+        @test eltype(S) == ComplexF64
+        @test size(S) == size(R)
+    end
 end


### PR DESCRIPTION
On master
```julia
julia> B = ApproxFunBase.brand(4,4,1,1)
4×4 BandedMatrix{Float64} with bandwidths (1, 1):
 0.491781  0.491816   ⋅         ⋅ 
 0.320611  0.941615  0.309694   ⋅ 
  ⋅        0.80753   0.90633   0.990165
  ⋅         ⋅        0.276171  0.920501

julia> R = ApproxFunBase.RaggedMatrix(B)
4×4 ApproxFunBase.RaggedMatrix{Float64}:
 0.491781  0.491816  0.0       0.0
 0.320611  0.941615  0.309694  0.0
 0.0       0.80753   0.90633   0.990165
 0.0       0.0       0.276171  0.920501

julia> similar(R, ComplexF64)
ERROR: MethodError: no method matching Vector{ComplexF64}(::Int64)
```
This PR
```julia
julia> similar(R, ComplexF64)
4×4 ApproxFunBase.RaggedMatrix{ComplexF64}:
 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
 0.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
```