### PR TITLE
domain promotion for cached operator

### DIFF
--- a/src/Caching/matrix.jl
+++ b/src/Caching/matrix.jl
@@ -1,5 +1,5 @@
 CachedOperator(::Type{Matrix},op::Operator;padding::Bool=false) =
-    CachedOperator(op,Array{eltype(op)}(0,0),padding)
+    CachedOperator(op,Array{eltype(op)}(undef,0,0),padding)
 
 
 # Grow cached operator

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -200,7 +200,7 @@ function unsafe_resize!(W::AbstractMatrix,n::Integer,::Colon)
         W[1:n,:]
     else
         m=size(W,2)
-        ret=Matrix{eltype(W)}(n,m)
+        ret=Matrix{eltype(W)}(undef, n,m)
         ret[1:N,:] = W
         ret
     end

--- a/src/Operators/general/CachedOperator.jl
+++ b/src/Operators/general/CachedOperator.jl
@@ -1,10 +1,4 @@
-
-
 export cache
-
-
-
-
 
 ## CachedOperator
 
@@ -85,7 +79,7 @@ function Base.getindex(B::CachedOperator,k::AbstractRange,j::AbstractRange)
         resizedata!(B,maximum(k),maximum(j))
         B.data[k,j]
     else
-        Matrix{eltype(B)}(length(k),length(j))
+        Matrix{eltype(B)}(undef, length(k),length(j))
     end
 end
 
@@ -114,17 +108,21 @@ end
     end
  end
 
-
-
-
-
-
 resizedata!(B::CachedOperator,::Colon,m::Integer) = resizedata!(B,size(B,1),m)
 resizedata!(B::CachedOperator,n::Integer,::Colon) = resizedata!(B,n,size(B,2))
-
 
 function mul_coefficients(B::CachedOperator,v::AbstractVector{T}) where T<:Number
     resizedata!(B,:,length(v))
 
     B.data*pad(v,size(B.data,2))
+end
+
+function promotedomainspace(C::CachedOperator,sp::Space)
+    C2 = promotedomainspace(C.op, sp)
+    cache(C2)
+end
+
+function promoterangespace(C::CachedOperator,sp::Space)
+    C2 = promoterangespace(C.op, sp)
+    cache(C2)
 end


### PR DESCRIPTION
Specialize `promotedomainspace` and `promoterangespace` for a `CachedOperator`, preserving the caching nature. Also, some bug-fixes in array initialization.
After this,
```julia
julia> cache(Derivative()) : Chebyshev()
CachedOperator : Chebyshev() → Ultraspherical(1)
 ⋅  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅   2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅   3.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅   4.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅   5.0   ⋅    ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅   6.0   ⋅    ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   7.0   ⋅    ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   8.0   ⋅   ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   9.0  ⋅
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
 ⋅   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱

julia> cache(Derivative()) : Chebyshev() → Ultraspherical(2)
CachedOperator : Chebyshev() → Ultraspherical(2)
 ⋅  1.0  0.0  -1.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅   1.0   0.0  -1.0    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅    1.0   0.0  -1.0    ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅    1.0   0.0  -1.0    ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅    1.0   0.0  -1.0    ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅    1.0   0.0  -1.0    ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    1.0   0.0  -1.0  ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    1.0   0.0  ⋱
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    1.0  ⋱
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
```