### PR TITLE
Cancel concurrent in downstream.yml

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,4 +1,9 @@
 name: IntegrationTest
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
This helps shift load off CI resources. Ideally this shouldn't be necessary, and the focus should be on making the tests run faster.