### PR TITLE
Fix `RowVector` methods

### DIFF
--- a/src/LinearAlgebra/rowvector.jl
+++ b/src/LinearAlgebra/rowvector.jl
@@ -9,13 +9,13 @@ import Base: convert, similar, length, size, axes, IndexStyle,
     RowVector(vector)
 
 A lazy-view wrapper of an `AbstractVector`, which turns a length-`n` vector into a `1×n`
-shaped row vector and represents the transpose of a vector (the elements are also transposed
-recursively).
+shaped row vector and represents the transpose of a vector (although unlike `transpose`,
+the elements are *not* transposed recursively).
 
 By convention, a vector can be multiplied by a matrix on its left (`A * v`) whereas a row
-vector can be multiplied by a matrix on its right (such that `transpose(v) * A = transpose(transpose(A) * v)`). It
+vector can be multiplied by a matrix on its right (such that `RowVector(v) * A = RowVector(transpose(A) * v)`). It
 differs from a `1×n`-sized matrix by the facts that its transpose returns a vector and the
-inner product `transpose(v1) * v2` returns a scalar, but will otherwise behave similarly.
+inner product `RowVector(v1) * v2` returns a scalar, but will otherwise behave similarly.
 """
 struct RowVector{T,V<:AbstractVector} <: AbstractMatrix{T}
     vec::V
@@ -29,13 +29,13 @@ end
 @inline RowVector{T}(vec::AbstractVector{T}) where {T} = RowVector{T,typeof(vec)}(vec)
 
 # Constructors that take a size and default to Array
-@inline RowVector{T}(n::Int) where {T} = RowVector{T}(Vector{T}(n))
+@inline RowVector{T}(n::Int) where {T} = RowVector{T}(Vector{T}(undef,n))
 @inline RowVector{T}(n1::Int, n2::Int) where {T} = n1 == 1 ?
-    RowVector{T}(Vector{T}(n2)) :
+    RowVector{T}(n2) :
     error("RowVector expects 1×N size, got ($n1,$n2)")
-@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(Vector{T}(n[1]))
+@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(n[1])
 @inline RowVector{T}(n::Tuple{Int,Int}) where {T} = n[1] == 1 ?
-    RowVector{T}(Vector{T}(n[2])) :
+    RowVector{T}(n[2]) :
     error("RowVector expects 1×N size, got $n")
 
 # Conversion of underlying storage
@@ -44,7 +44,7 @@ convert(::Type{RowVector{T,V}}, rowvec::RowVector) where {T,V<:AbstractVector} =
 
 # similar tries to maintain the RowVector wrapper and the parent type
 @inline similar(rowvec::RowVector) = RowVector(similar(parent(rowvec)))
-@inline similar(rowvec::RowVector, ::Type{T}) where {T} = RowVector(similar(parent(rowvec), transpose_type(T)))
+@inline similar(rowvec::RowVector, ::Type{T}) where {T} = RowVector(similar(parent(rowvec), T))
 
 # Resizing similar currently loses its RowVector property.
 @inline similar(rowvec::RowVector, ::Type{T}, dims::Dims{N}) where {T,N} = similar(parent(rowvec), T, dims)
@@ -54,40 +54,17 @@ parent(rowvec::RowVector) = rowvec.vec
 # AbstractArray interface
 @inline length(rowvec::RowVector) =  length(rowvec.vec)
 @inline size(rowvec::RowVector) = (1, length(rowvec.vec))
-@inline size(rowvec::RowVector, d) = ifelse(d==2, length(rowvec.vec), 1)
-@inline axes(rowvec::RowVector) = (Base.OneTo(1), axes(rowvec.vec)[1])
-@inline axes(rowvec::RowVector, d) = ifelse(d == 2, axes(rowvec.vec)[1], Base.OneTo(1))
+@inline axes(rowvec::RowVector) = (Base.OneTo(1), axes(rowvec.vec, 1))
 IndexStyle(::RowVector) = IndexLinear()
 IndexStyle(::Type{<:RowVector}) = IndexLinear()
 
-
-@propagate_inbounds getindex(rowvec::RowVector, i) = rowvec.vec[i]
-@propagate_inbounds setindex!(rowvec::RowVector, v, i) = setindex!(rowvec.vec, v, i)
-
-# Cartesian indexing is distorted by getindex
-# Furthermore, Cartesian indexes don't have to match shape, apparently!
-@inline function getindex(rowvec::RowVector, i::CartesianIndex)
-    @boundscheck if !(i.I[1] == 1 && i.I[2] ∈ axes(rowvec.vec)[1] && check_tail_indices(i.I...))
-        throw(BoundsError(rowvec, i.I))
-    end
-    @inbounds return rowvec.vec[i.I[2]]
-end
-@inline function setindex!(rowvec::RowVector, v, i::CartesianIndex)
-    @boundscheck if !(i.I[1] == 1 && i.I[2] ∈ axes(rowvec.vec)[1] && check_tail_indices(i.I...))
-        throw(BoundsError(rowvec, i.I))
-    end
-    @inbounds rowvec.vec[i.I[2]] = v
-end
-
-@propagate_inbounds getindex(rowvec::RowVector, ::CartesianIndex{0}) = getindex(rowvec)
-@propagate_inbounds getindex(rowvec::RowVector, i::CartesianIndex{1}) = getindex(rowvec, i.I[1])
-
-@propagate_inbounds setindex!(rowvec::RowVector, v, ::CartesianIndex{0}) = setindex!(rowvec, v)
-@propagate_inbounds setindex!(rowvec::RowVector, v, i::CartesianIndex{1}) = setindex!(rowvec, v, i.I[1])
+@propagate_inbounds getindex(rowvec::RowVector, i::Int) = rowvec.vec[i]
+@propagate_inbounds setindex!(rowvec::RowVector, v, i::Int) = setindex!(rowvec.vec, v, i)
 
 # helper function for below
-@inline to_vec(rowvec::RowVector) = rowvec.vec
-
+to_vec(r::RowVector) = parent(r)
+to_vec(x) = x
+@inline to_vecs(rowvecs...) = map(to_vec, rowvecs)
 # map: Preserve the RowVector by un-wrapping and re-wrapping, but note that `f`
 # expects to operate within the transposed domain, so to_vec transposes the elements
 @inline map(f, rowvecs::RowVector...) = RowVector(map(f, to_vecs(rowvecs...)...))
@@ -98,13 +75,13 @@ end
 
 # Horizontal concatenation #
 
-@inline hcat(X::RowVector...) = RowVector(vcat(X...))
-@inline hcat(X::Union{RowVector,Number}...) = RowVector(vcat(X...))
+@inline hcat(X::RowVector...) = RowVector(mapreduce(parent, vcat, X))
+@inline hcat(X::Union{RowVector,Number}...) = RowVector(mapreduce(to_vec, vcat, X))
 
 @inline typed_hcat(::Type{T}, X::RowVector...) where {T} =
-    RowVector(typed_vcat(T, X...))
+    RowVector(Base.typed_vcat(T, to_vecs(X...)...))
 @inline typed_hcat(::Type{T}, X::Union{RowVector,Number}...) where {T} =
-    RowVector(typed_vcat(T, X...))
+    RowVector(Base.typed_vcat(T, to_vecs(X...)...))
 
 # Multiplication #
 
@@ -116,9 +93,9 @@ end
     if length(rowvec) != length(vec)
         throw(DimensionMismatch("A has dimensions $(size(rowvec)) but B has dimensions $(size(vec))"))
     end
-    sum(@inbounds(rowvec[i]*vec[i]) for i = 1:length(vec))
+    sum(@inbounds(rowvec[i]*vec[i]) for i in eachindex(rowvec, vec))
 end
-@inline *(rowvec::RowVector, mat::AbstractMatrix) = RowVector(transpose(transpose()mat) * rowvec.vec)
+@inline *(rowvec::RowVector, mat::AbstractMatrix) = RowVector(transpose(mat) * parent(rowvec))
 *(::RowVector, ::RowVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))
 @inline *(vec::AbstractVector, rowvec::RowVector) = vec .* rowvec
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,6 +270,51 @@ end
     end
 end
 
+@testset "RowVector" begin
+    @testset "constructors" begin
+        for s in [(2,), (1,2)], sz in [s, (s,)]
+            b = fill!(ApproxFunBase.RowVector{Int}(sz...), 2)
+            @test size(b) == (1,2)
+            @test all(==(2), b)
+        end
+    end
+    # for a vector of numbers, RowVector should be identical to transpose
+    a = Float64.(1:4)
+    at = transpose(a)
+    b = ApproxFunBase.RowVector(a)
+    @test b == at
+    for inds in [eachindex(b), CartesianIndices(b)]
+        for i in inds
+            @test b[i] == at[i]
+        end
+    end
+    M = Float64.(reshape(1:16, 4, 4))
+    @test b * M == at * M
+    @test b * a == at * a
+    @test b * Float32.(a) == at * Float32.(a)
+    @test a * b == a * at
+    @test map(x->x^2, b) == map(x->x^2, at)
+    @test b.^2 == at.^2
+    @test hcat(b, b) == hcat(at, at)
+    @test vcat(b, b) == vcat(at, at)
+    @test hcat(b, 1) == hcat(at, 1)
+    c = Float32[b 1]
+    @test eltype(c) == Float32
+    @test c == [b 1]
+    c = Float32[b b]
+    @test eltype(c) == Float32
+    @test c == Float32[at at]
+
+    # setindex
+    b[2] = 30
+    @test b[2] == b[1,2] == 30
+    @test a[2] == 30
+
+    a = rand(1)
+    b = ApproxFunBase.RowVector(a)
+    @test b[] == b[CartesianIndex()] == b[CartesianIndex(1)] == a[]
+end
+
 @testset "misc" begin
     a = @inferred ApproxFunBase.specialfunctionnormalizationpoint(exp,real,Fun())
     @test a[1] == 1


### PR DESCRIPTION
Modernize the constructors, and remove explicit indexing methods (fallback implementations should be fast enough). Also fixes concatenation etc.