### PR TITLE
Improve inference in `norm`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.6.19"
+version = "0.6.20"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -412,9 +412,12 @@ lineinnerproduct(g::Fun,c::Number)=linebilinearform(conj(g),c)
 
 for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
     @eval begin
-        $OP(f::Fun) = sqrt(abs($SUM(abs2(f))))
+        $OP(f::Fun) = norm(f, 2)
 
-        function $OP(f::Fun{<:Space{<:Any,<:Number}}, p::Real)
+        # Specializing norm(::ScalarFun) helps with inference
+        $OP(f::ScalarFun) = sqrt(abs($SUM(abs2(f))))
+
+        function $OP(f::ScalarFun, p::Real)
             if p < 1
                 return error("p should be 1 ≤ p ≤ ∞")
             elseif 1 ≤ p < Inf
@@ -424,8 +427,9 @@ for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
             end
         end
 
-        function $OP(f::Fun{<:Space{<:Any,<:Number}}, p::Int)
+        function $OP(f::ScalarFun, p::Int)
             if 1 ≤ p < Inf
+                p == 2 && return $OP(f)
                 return iseven(p) ? abs($SUM(abs2(f)^(p÷2)))^(1/p) : abs($SUM(abs2(f)^(p/2)))^(1/p)
             else
                 error("p should be 1 ≤ p ≤ ∞")

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -412,7 +412,7 @@ lineinnerproduct(g::Fun,c::Number)=linebilinearform(conj(g),c)
 
 for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
     @eval begin
-        $OP(f::Fun) = sqrt($SUM(abs2(f)))
+        $OP(f::Fun) = sqrt(abs($SUM(abs2(f))))
 
         function $OP(f::Fun{<:Space{<:Any,<:Number}}, p::Real)
             if p < 1

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -412,7 +412,7 @@ lineinnerproduct(g::Fun,c::Number)=linebilinearform(conj(g),c)
 
 for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
     @eval begin
-        $OP(f::Fun) = $OP(f, 2)
+        $OP(f::Fun) = $OP(f,2)
 
         # Specializing norm(::ScalarFun) helps with inference
         $OP(f::ScalarFun) = sqrt(abs($SUM(abs2(f))))

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -412,7 +412,7 @@ lineinnerproduct(g::Fun,c::Number)=linebilinearform(conj(g),c)
 
 for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
     @eval begin
-        $OP(f::Fun) = norm(f, 2)
+        $OP(f::Fun) = $OP(f, 2)
 
         # Specializing norm(::ScalarFun) helps with inference
         $OP(f::ScalarFun) = sqrt(abs($SUM(abs2(f))))

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -412,7 +412,7 @@ lineinnerproduct(g::Fun,c::Number)=linebilinearform(conj(g),c)
 
 for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
     @eval begin
-        $OP(f::Fun) = $OP(f,2)
+        $OP(f::Fun) = sqrt($SUM(abs2(f)))
 
         function $OP(f::Fun{<:Space{<:Any,<:Number}}, p::Real)
             if p < 1
@@ -428,7 +428,7 @@ for (OP,SUM) in ((:(norm),:(sum)),(:linenorm,:linesum))
             if 1 ≤ p < Inf
                 return iseven(p) ? abs($SUM(abs2(f)^(p÷2)))^(1/p) : abs($SUM(abs2(f)^(p/2)))^(1/p)
             else
-                return error("p should be 1 ≤ p ≤ ∞")
+                error("p should be 1 ≤ p ≤ ∞")
             end
         end
     end

--- a/src/Multivariate/VectorFun.jl
+++ b/src/Multivariate/VectorFun.jl
@@ -138,7 +138,6 @@ end
 # use standard +, -
 *(A::ArrayFun,f::ArrayFun) = Fun(Array(A)*Array(f))
 
-norm(A::VectorFun) = norm(A, 2)
 norm(A::VectorFun, p::Real) = norm(norm.(Array(A)),p)
 
 

--- a/src/Multivariate/VectorFun.jl
+++ b/src/Multivariate/VectorFun.jl
@@ -138,8 +138,8 @@ end
 # use standard +, -
 *(A::ArrayFun,f::ArrayFun) = Fun(Array(A)*Array(f))
 
+norm(A::VectorFun) = norm(A, 2)
 norm(A::VectorFun, p::Real) = norm(norm.(Array(A)),p)
-
 
 
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -252,7 +252,7 @@ using LinearAlgebra
 
     @testset "ApproxFunOrthogonalPolynomials" begin
         @test (@inferred Fun()) == Fun(x->x, Chebyshev())
-        @test (@inferred norm(Fun())) ≈ √(2/3) # √∫x^2 dx over -1..1
+        @test (@inferred norm(Fun())) ≈ norm(Fun(), 2) ≈ √(2/3) # √∫x^2 dx over -1..1
 
         v = rand(4)
         v2 = transform(NormalizedChebyshev(), v)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -252,6 +252,7 @@ using LinearAlgebra
 
     @testset "ApproxFunOrthogonalPolynomials" begin
         @test (@inferred Fun()) == Fun(x->x, Chebyshev())
+        @test (@inferred norm(Fun())) ≈ √(2/3) # √∫x^2 dx over -1..1
 
         v = rand(4)
         v2 = transform(NormalizedChebyshev(), v)


### PR DESCRIPTION
For some reason, constant propagation isn't working here, so explicitly defining the function helps with inference.
## Inference
On master
```julia
julia> @code_warntype norm(Fun())
MethodInstance for LinearAlgebra.norm(::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}})
  from norm(f::Fun) in ApproxFunBase at /home/jb6888/Dropbox/JuliaPackages/ApproxFunBase/src/Fun.jl:415
Arguments
  #self#::Core.Const(LinearAlgebra.norm)
  f::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}
Body::Any
1 ─ %1 = ApproxFunBase.norm(f, 2)::Any
└──      return %1
```

This PR
```julia
julia> @code_warntype norm(Fun())
MethodInstance for LinearAlgebra.norm(::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}})
  from norm(f::Fun) in ApproxFunBase at /home/jb6888/Dropbox/JuliaPackages/ApproxFunBase/src/Fun.jl:415
Arguments
  #self#::Core.Const(LinearAlgebra.norm)
  f::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}
Body::Float64
1 ─ %1 = ApproxFunBase.abs2(f)::Fun{Chebyshev{ChebyshevInterval{Float64}, Float64}, Float64, Vector{Float64}}
│   %2 = ApproxFunBase.sum(%1)::Float64
│   %3 = ApproxFunBase.abs(%2)::Float64
│   %4 = ApproxFunBase.sqrt(%3)::Float64
└──      return %4
```

## TTFX
On master
```julia
julia> @time @eval norm(Fun())
 33.539845 seconds (89.62 M allocations: 5.247 GiB, 6.09% gc time, 100.00% compilation time)
0.816496580927726
```
This PR
```julia
julia> @time @eval norm(Fun())
  5.011131 seconds (11.31 M allocations: 665.392 MiB, 16.71% gc time, 99.85% compilation time)
0.816496580927726
```
This should help significantly with downstream tests