### PR TITLE
Support euler exponentiation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -196,6 +196,8 @@ for (op, ODE, RHS, growth) in ((:(exp),    "D-f'",           "0",        :(real)
     end
 end
 
+Base.:(^)(::Irrational{:ℯ}, f::Fun) = exp(f)
+
 function specialfunctionnormalizationpoint2(op, growth, f, T = cfstype(f))
     xmin, xmax, opfxmin, opfxmax, opmax = _specialfunctionnormalizationpoint(op,growth,f)
     while opmax≤10eps(T) || abs(f(xmin)-f(xmax))≤10eps(T)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -149,6 +149,12 @@ using LinearAlgebra
                 @test g(i) == h(i)
             end
         end
+
+        @testset "euler and exp" begin
+            f = Fun(PointSpace(1:3), 1:3)
+            @test ℯ^f == exp(f)
+            @test values(ℯ^f) == exp.(values(f))
+        end
     end
 
     @testset "DiracSpace" begin


### PR DESCRIPTION
This makes `ℯ^x` redirect to `exp(x)` for `x::Fun`
Fixes https://github.com/JuliaApproximation/ApproxFun.jl/issues/434