### PR TITLE
improve inference in literal exponentiation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -65,6 +65,8 @@ domainscompatible(a,b) = domainscompatible(domain(a),domain(b))
 domainscompatible(a::Domain,b::Domain) = isambiguous(a) || isambiguous(b) ||
                     isapprox(a,b)
 
+domainscompatible(::ChebyshevInterval, ::ChebyshevInterval) = true
+
 ##TODO: Should fromcanonical be fromcanonical!?
 
 #TODO consider moving these

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -305,7 +305,7 @@ for op in (:+,:-)
             end
         end
         $op(f::Fun{S,T},c::T) where {S,T<:Number} = c==0 ? f : $op(f,Fun(c))
-        $op(f::Fun,c::Number) = $op(f,Fun(c))
+        $op(f::Fun,c::Number) = $op(f,Fun(c, space(f)))
         $op(f::Fun,c::UniformScaling) = $op(f,c.λ)
         $op(c::UniformScaling,f::Fun) = $op(c.λ,f)
     end
@@ -356,11 +356,11 @@ end
 
 function intpow(f::Fun,k::Integer)
     if k == 0
-        ones(space(f))
+        ones(cfstype(f), space(f))
     elseif k==1
         f
     else
-        t = reduce(*, fill(f, abs(k)))
+        t = foldl(*, fill(f, abs(k)))
         if k > 0
             return t
         else
@@ -370,12 +370,6 @@ function intpow(f::Fun,k::Integer)
 end
 
 ^(f::Fun, k::Integer) = intpow(f,k)
-# some common cases
-Base.literal_pow(::typeof(^), x::Fun, ::Val{0}) = ones(cfstype(x), space(x))
-Base.literal_pow(::typeof(^), x::Fun, ::Val{1}) = x
-Base.literal_pow(::typeof(^), x::Fun, ::Val{2}) = x * x
-Base.literal_pow(::typeof(^), x::Fun, ::Val{3}) = x * x * x
-Base.literal_pow(::typeof(^), x::Fun, ::Val{4}) = x * x * x * x
 
 inv(f::Fun) = 1/f
 

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -305,7 +305,7 @@ for op in (:+,:-)
             end
         end
         $op(f::Fun{S,T},c::T) where {S,T<:Number} = c==0 ? f : $op(f,Fun(c))
-        $op(f::Fun,c::Number) = $op(f,Fun(c, space(f)))
+        $op(f::Fun,c::Number) = $op(f,Fun(c))
         $op(f::Fun,c::UniformScaling) = $op(f,c.λ)
         $op(c::UniformScaling,f::Fun) = $op(c.λ,f)
     end

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -252,7 +252,10 @@ Space(sp::ProductDomain) = TensorSpace(sp)
 setdomain(sp::TensorSpace, d::ProductDomain) = TensorSpace(setdomain.(factors(sp), factors(d)))
 
 *(A::Space, B::Space) = A⊗B
-^(A::Space, p::Integer) = p == 1 ? A : A*A^(p-1)
+function ^(A::Space, p::Integer)
+    p >= 1 || throw(ArgumentError("exponent must be >= 1, received $p"))
+    p == 1 ? A : foldl(*, ntuple(_ -> A, p))
+end
 
 
 ## TODO: generalize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,11 @@ end
     @test Segment(1,2) .^ 2 ≡ Segment(1,4)
     @test sqrt.(Segment(1,2)) ≡ Segment(1,sqrt(2))
 
+    @testset "ChebyshevInterval" begin
+        @test @inferred ApproxFunBase.domainscompatible(ChebyshevInterval{Float64}(), ChebyshevInterval{Float32}())
+        @test @inferred ApproxFunBase.domainscompatible(ChebyshevInterval{Float64}(), ChebyshevInterval{BigFloat}())
+    end
+
     @testset "union" begin
         a = ApproxFunBase.EmptyDomain()
         b = ApproxFunBase.AnyDomain()


### PR DESCRIPTION
After this, the following are type-inferred on Julia v1.8:
```julia
julia> @inferred (() -> Chebyshev()^2)()
Chebyshev()⊗Chebyshev()

julia> y = @inferred Fun() + Fun(ChebyshevInterval{BigFloat}())
Fun(Chebyshev(), BigFloat[0.0, 2.0])
```
Tests to be added to `ApproxFunOrthogonalPolynomials`.