### PR TITLE
improve inference in space tensor product

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -254,7 +254,11 @@ setdomain(sp::TensorSpace, d::ProductDomain) = TensorSpace(setdomain.(factors(sp
 *(A::Space, B::Space) = A⊗B
 function ^(A::Space, p::Integer)
     p >= 1 || throw(ArgumentError("exponent must be >= 1, received $p"))
-    p == 1 ? A : foldl(*, ntuple(_ -> A, p))
+    # Enumerate common cases to help with constant propagation
+    p == 1 ? A :
+    p == 2 ? A * A :
+    p == 3 ? A * A * A :
+    foldl(*, ntuple(_ -> A, p))
 end
 
 

--- a/src/Spaces/ArraySpace.jl
+++ b/src/Spaces/ArraySpace.jl
@@ -234,8 +234,8 @@ Fun(M::UniformScaling,sp::MatrixSpace) = Fun(M.λ*Matrix(I,size(sp)...),sp)
 
 
 
-ones(::Type{T},A::ArraySpace) where {T<:Number} = Fun(ones.(T,spaces(A)))
-ones(A::ArraySpace) = Fun(ones.(spaces(A)))
+ones(::Type{T},A::ArraySpace) where {T<:Number} = Fun(ones.(T,A.spaces))
+ones(A::ArraySpace) = ones(Float64, A)
 
 
 ## EuclideanSpace

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -62,11 +62,19 @@ using LinearAlgebra
             end
         end
         @testset "intpow" begin
+            sp = PointSpace(1:3)
+            f = Fun(sp, Float64[1:3;])
             @test ApproxFunBase.intpow(f, 0) == f^0 == Fun(space(f), ones(ncoefficients(f)))
             for n in 1:3
                 @test ApproxFunBase.intpow(f, n) == f^n == reduce(*, fill(f, n))
             end
             @test ApproxFunBase.intpow(f,-2) == f^-2 == 1/(f*f)
+
+            @test sp^1 == sp
+            @test sp^2 == sp * sp
+            @test sp^3 == sp * sp * sp
+            @test sp^4 == sp * sp * sp * sp
+            @test sp^5 == sp * sp * sp * sp * sp
         end
 
         @testset "Fun accepts callables" begin


### PR DESCRIPTION
This helps with inference:
```julia
julia> @inferred (() -> Chebyshev()^2)()
Chebyshev()⊗Chebyshev()

julia> @inferred (() -> Chebyshev()^3)()
Chebyshev()⊗Chebyshev()⊗Chebyshev()

julia> @inferred (() -> Chebyshev(0..1)^3)()
Chebyshev(0..1)⊗Chebyshev(0..1)⊗Chebyshev(0..1)
```
Also fixes `one(f)` for `Fun`s on `ArraySpace`s:
```julia
julia> f = Fun(x->[x, x], -1..1)
Fun(2-element ArraySpace:
Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}[Chebyshev(-1..1), Chebyshev(-1..1)], [0.0, 0.0, 1.0, 1.0])

julia> f + one(f)
Fun(2-element ArraySpace:
Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}[Chebyshev(-1..1), Chebyshev(-1..1)], [1.0, 1.0, 1.0, 1.0])
```