### PR TITLE
aggressive constprop in intpow

### DIFF
--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -353,8 +353,12 @@ end
 
 \(c::Number, f::Fun) = Fun(f.space, c \ f.coefficients)
 
-
-function intpow(f::Fun,k::Integer)
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive intpow(f::Fun, k::Integer) = _intpow(f, k)
+else
+    intpow(f::Fun, k::Integer) = _intpow(f, k)
+end
+@inline function _intpow(f, k)
     if k == 0
         ones(cfstype(f), space(f))
     elseif k==1


### PR DESCRIPTION
This simplifies branches in code where the exponent isn't a literal constant
```julia
julia> f = Fun(0..1)
Fun(Chebyshev(0..1), [0.5, 0.5])

julia> function g(f)
           n = 2
           f^n
       end
```
On master:
```julia
julia> @code_typed g(f)
CodeInfo(
1 ─ %1 = π (2, Int64)
│   %2 = invoke ApproxFunOrthogonalPolynomials.intpow(f::Function, %1::Int64)::Any
└──      return %2
) => Any
```
This PR
```julia
julia> @code_typed g(f)
CodeInfo(
1 ─ %1 = invoke ApproxFunBase.default_mult(f::Fun{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Float64, Vector{Float64}}, f::Fun{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Float64, Vector{Float64}})::Any
└──      return %1
) => Any
```