### PR TITLE
Add extra spaces while displaying a `TensorSpace`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -171,7 +171,7 @@ function show(io::IO,s::TensorSpace)
     d = length(s.spaces)
     for i=1:d-1
         show(io,s.spaces[i])
-        print(io,"⊗ ")
+        print(io," ⊗ ")
     end
     show(io,s.spaces[d])
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -171,7 +171,7 @@ function show(io::IO,s::TensorSpace)
     d = length(s.spaces)
     for i=1:d-1
         show(io,s.spaces[i])
-        print(io,"⊗")
+        print(io,"⊗ ")
     end
     show(io,s.spaces[d])
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -15,10 +15,11 @@
 			@test contains(repr(c), repr(domain(c)))
 		end
 		@testset "TensorSpace" begin
-			S = Chebyshev() ⊗ Chebyshev()
+			S1 = PointSpace(1:3)
+			S = S1 ⊗ S1
 			v = strip.(split(repr(S), '⊗'))
 			@test length(v) == 2
-			@test all(==("Chebyshev()"), v)
+			@test all(==(repr(S1)), v)
 		end
 	end
 	@testset "Fun" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -14,6 +14,12 @@
 			@test contains(repr(c), "ConstantSpace")
 			@test contains(repr(c), repr(domain(c)))
 		end
+		@testset "TensorSpace" begin
+			S = Chebyshev() ⊗ Chebyshev()
+			v = strip.(split(repr(S), '⊗'))
+			@test length(v) == 2
+			@test all(==("Chebyshev()"), v)
+		end
 	end
 	@testset "Fun" begin
 		f = Fun(PointSpace(1:3), [1,2,3])


### PR DESCRIPTION
This improves the display of tensor spaces using certain fonts, while being mildly inconvenient in others. This also helps with tab-completion in the REPL, which seems to only work with the extra spaces present.

Before
```julia
julia> Chebyshev() ⊗ Chebyshev()
Chebyshev()⊗Chebyshev()
```
After
```julia
julia> Chebyshev() ⊗ Chebyshev()
Chebyshev() ⊗ Chebyshev()
```