### PR TITLE
All coeffs in `fromtensor`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.16"
+version = "0.7.17"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -472,10 +472,9 @@ end
 fromtensor(S::Space,M::AbstractMatrix) = fromtensor(tensorizer(S),M)
 totensor(S::Space,M::AbstractVector) = totensor(tensorizer(S),M)
 
-# we only copy upper triangular of coefficients
 function fromtensor(it::Tensorizer,M::AbstractMatrix)
     n,m=size(M)
-    ret=zeros(eltype(M),blockstop(it,max(n,m)))
+    ret=zeros(eltype(M),blockstop(it,max(n,m)+1))
     k = 1
     for (K,J) in it
         if k > length(ret)


### PR DESCRIPTION
This fixes
```julia
julia> f(x,y) = x*y
f (generic function with 1 method)

julia> L = LowRankFun(f, Chebyshev() ⊗ Chebyshev())
LowRankFun on Chebyshev() ⊗ Chebyshev() of rank 1.

julia> F = Fun(L)
Fun(Chebyshev() ⊗ Chebyshev(), [0.0, 0.0, 0.0, 0.0, 1.0])

julia> L(0.1, 0.2) ≈ F(0.1, 0.2)
true
```