### PR TITLE
improve inference in LowRankFun

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.17"
+version = "0.7.18"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
This makes the `LowRankFun` constructor fully type-inferrable:
```julia
julia> @inferred LowRankFun((x,y) -> exp(x) * cos(y))
LowRankFun on Chebyshev() ⊗ Chebyshev() of rank 1.
```