### PR TITLE
function barrier in SubOperator

### DIFF
--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -50,14 +50,21 @@ SubOperator(A,inds,dims::Tuple{Bool,Bool},lu) = SubOperator(A,inds,Int.(dims),lu
 
 function SubOperator(A,inds::NTuple{2,Block},lu)
     checkbounds(A,inds...)
-    SubOperator(A,inds,(blocklengths(rangespace(A))[inds[1].n[1]],blocklengths(domainspace(A))[inds[2].n[1]]),lu)
+    _SubOperator(A, inds, lu, dsp, rsp)
+end
+function _SubOperator(A, inds, lu, dsp, rsp)
+    SubOperator(A,inds,(blocklengths(rsp)[inds[1].n[1]],
+                        blocklengths(dsp)[inds[2].n[1]]),lu)
 end
 
 SubOperator(A, inds::NTuple{2,Block}) = SubOperator(A,inds,subblockbandwidths(A))
 function SubOperator(A, inds::Tuple{BlockRange{1,R},BlockRange{1,R}}) where R
     checkbounds(A,inds...)
-    dims = (sum(blocklengths(rangespace(A))[inds[1].indices[1]]),
-            sum(blocklengths(domainspace(A))[inds[2].indices[1]]))
+    _SubOperator(A, inds, domainspace(A), rangespace(A))
+end
+function _SubOperator(A, inds, dsp, rsp)
+    dims = (sum(blocklengths(rsp)[inds[1].indices[1]]),
+            sum(blocklengths(dsp)[inds[2].indices[1]]))
     SubOperator(A,inds,dims,(dims[1]-1,dims[2]-1))
 end
 

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -50,7 +50,7 @@ SubOperator(A,inds,dims::Tuple{Bool,Bool},lu) = SubOperator(A,inds,Int.(dims),lu
 
 function SubOperator(A,inds::NTuple{2,Block},lu)
     checkbounds(A,inds...)
-    _SubOperator(A, inds, lu, dsp, rsp)
+    _SubOperator(A, inds, lu, domainspace(A), rangespace(A))
 end
 function _SubOperator(A, inds, lu, dsp, rsp)
     SubOperator(A,inds,(blocklengths(rsp)[inds[1].n[1]],


### PR DESCRIPTION
Since domain and range spaces might be poorly inferred, introducing a function barrier might provide some performance improvements.
```julia
julia> dx=0..1; dt=0.0..0.001
0.0..0.001

julia> C=Conversion(Chebyshev(dx)*Ultraspherical(1,dt),Ultraspherical(2,dx)*Ultraspherical(1,dt));

julia> @time C[Block.(1:4),Block.(1:4)];
  5.071718 seconds (12.10 M allocations: 614.771 MiB, 5.35% gc time, 99.93% compilation time)
```
Second run performance
```julia
julia> @time C[Block.(1:4),Block.(1:4)];
  0.000195 seconds (97 allocations: 8.078 KiB) # master
  0.000105 seconds (91 allocations: 7.922 KiB) # PR
```
