### PR TITLE
move tests to a separate module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.21"
+version = "0.7.22"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -1,5 +1,5 @@
 module ApproxFunBase
-    using Base: AnyDict
+using Base: AnyDict
 using Base, BlockArrays, BandedMatrices, BlockBandedMatrices, DomainSets, IntervalSets,
             SpecialFunctions, AbstractFFTs, FFTW, SpecialFunctions, DSP, DualNumbers,
             LinearAlgebra, SparseArrays, LowRankApprox, FillArrays, InfiniteArrays, InfiniteLinearAlgebra #, Arpack

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -1,14 +1,26 @@
-## Testing
+module ApproxFunBaseTest
+
+using ApproxFunBase
+using ApproxFunBase: plan_transform, plan_itransform, israggedbelow
+using BandedMatrices
+using BandedMatrices: rowstart, rowstop, colstart, colstop
+using BlockArrays
+using BlockBandedMatrices
+using DomainSets: dimension
+using LinearAlgebra
+using Test
+
 # These routines are for the unit tests
 
-using Test
+export testspace, testfunctional, testraggedbelowoperator, testbandedblockbandedoperator,
+    testbandedoperator
 
 ## Spaces Tests
 
 
 function testtransforms(S::Space;minpoints=1,invertibletransform=true)
     # transform tests
-    v = rand(max(minpoints,min(100,ApproxFunBase.dimension(S))))
+    v = rand(max(minpoints,min(100,dimension(S))))
     plan = plan_transform(S,v)
     @test transform(S,v)  == plan*v
 
@@ -227,3 +239,7 @@ function testbandedblockbandedoperator(A)
 
     @test isa(A[Block.(1:4),Block.(1:4)], BandedBlockBandedMatrix)
 end
+
+end
+
+using .ApproxFunBaseTest

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -13,7 +13,7 @@ using Test
 # These routines are for the unit tests
 
 export testspace, testfunctional, testraggedbelowoperator, testbandedblockbandedoperator,
-    testbandedoperator
+    testbandedoperator, testtransforms, testcalculus, testmultiplication, testinfoperator
 
 ## Spaces Tests
 

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -1,19 +1,24 @@
 module ApproxFunBaseTest
 
 using ApproxFunBase
-using ApproxFunBase: plan_transform, plan_itransform, israggedbelow
-using BandedMatrices
-using BandedMatrices: rowstart, rowstop, colstart, colstop
+using ApproxFunBase: plan_transform, plan_itransform, israggedbelow, RaggedMatrix, isbandedbelow, isbanded,
+    blockstart, blockstop, resizedata!
+using BandedMatrices: rowstart, rowstop, colstart, colstop, BandedMatrix, bandwidth
 using BlockArrays
 using BlockBandedMatrices
 using DomainSets: dimension
+using InfiniteArrays
 using LinearAlgebra
 using Test
 
 # These routines are for the unit tests
 
 export testspace, testfunctional, testraggedbelowoperator, testbandedblockbandedoperator,
-    testbandedoperator, testtransforms, testcalculus, testmultiplication, testinfoperator
+    testbandedoperator, testtransforms, testcalculus, testmultiplication, testinfoperator,
+    testblockbandedoperator, testbandedbelowoperator
+
+# assert type in convert
+strictconvert(::Type{T}, x) where {T} = convert(T, x)::T
 
 ## Spaces Tests
 

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -250,3 +250,4 @@ end
 end
 
 using .ApproxFunBaseTest
+export ApproxFunBaseTest

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -5,7 +5,9 @@ using ApproxFunBase: plan_transform, plan_itransform, israggedbelow, RaggedMatri
     blockstart, blockstop, resizedata!
 using BandedMatrices: rowstart, rowstop, colstart, colstop, BandedMatrix, bandwidth
 using BlockArrays
+using BlockArrays: blockrowstop, blockcolstop
 using BlockBandedMatrices
+using BlockBandedMatrices: isbandedblockbanded
 using DomainSets: dimension
 using InfiniteArrays
 using LinearAlgebra


### PR DESCRIPTION
The idea is to move testing convenience functions to a separate package, one that may be imported downstream. This way, `ApproxFunBase` doesn't need to depend on `Test`. This PR is the first step that resolve namespace issues. Next, downstream packages need to be updated to import testing functions from `ApproxFunBaseTest` instead of from `ApproxFunBase`.