### PR TITLE
Don't export `ApproxFunBaseTest`

### DIFF
--- a/src/testing.jl
+++ b/src/testing.jl
@@ -250,4 +250,3 @@ end
 end
 
 using .ApproxFunBaseTest
-export ApproxFunBaseTest


### PR DESCRIPTION
This should not be necessary, as the individual test routines are imported downstream.