### PR TITLE
Kronecker operator acting on `LowRankFun`/`ProductFun`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.23"
+version = "0.7.24"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/Multivariate.jl
+++ b/src/Multivariate/Multivariate.jl
@@ -44,7 +44,7 @@ Fun(f::MultivariateFun,sp::Space) = Fun(Fun(f),sp)
 
 Fun(f,d1::Domain,d2::Domain) = Fun(f,d1*d2)
 
-coefficients(f::BivariateFun,sp::TensorSpace)=coefficients(f,sp[1],sp[2])
+coefficients(f::BivariateFun,sp::TensorSpace)=coefficients(f, factors(sp)...)
 
 
 

--- a/src/Multivariate/ProductFun.jl
+++ b/src/Multivariate/ProductFun.jl
@@ -66,11 +66,18 @@ function ProductFun(cfs::AbstractMatrix{T},sp::AbstractProductSpace{Tuple{S,V},D
     if chopping
         ncfs, kend = norm(cfs,Inf), size(cfs,2)
         if kend > 1
-            while isempty(chop(@view(cfs[:,kend]), ncfs*tol))
+            while kend > 0
+                if all(iszero, @view(cfs[:, kend]))
+                    kend -= 1
+                    continue
+                end
+                if !isempty(chop(@view(cfs[:,kend]), ncfs*tol))
+                    break
+                end
                 kend-=1
             end
         end
-        ret=VFun{S,T}[Fun(columnspace(sp,k),chop(cfs[:,k],ncfs*tol)) for k=1:max(kend,1)]
+        ret=VFun{S,T}[Fun(columnspace(sp,k),chop(@view(cfs[:,k]), ncfs*tol)) for k=1:max(kend,1)]
         ProductFun{S,V,typeof(sp),T}(ret,sp)
     else
         ret=VFun{S,T}[Fun(columnspace(sp,k),cfs[:,k]) for k=1:size(cfs,2)]

--- a/src/Multivariate/ProductFun.jl
+++ b/src/Multivariate/ProductFun.jl
@@ -62,10 +62,14 @@ true
 ```
 """
 function ProductFun(cfs::AbstractMatrix{T},sp::AbstractProductSpace{Tuple{S,V},DD};
-  tol::Real=100eps(T),chopping::Bool=false) where {S<:UnivariateSpace,V<:UnivariateSpace,T<:Number,DD}
+    tol::Real=100eps(T),chopping::Bool=false) where {S<:UnivariateSpace,V<:UnivariateSpace,T<:Number,DD}
     if chopping
-        ncfs,kend=norm(cfs,Inf),size(cfs,2)
-        if kend > 1 while isempty(chop(cfs[:,kend],ncfs*tol)) kend-=1 end end
+        ncfs, kend = norm(cfs,Inf), size(cfs,2)
+        if kend > 1
+            while isempty(chop(@view(cfs[:,kend]), ncfs*tol))
+                kend-=1
+            end
+        end
         ret=VFun{S,T}[Fun(columnspace(sp,k),chop(cfs[:,k],ncfs*tol)) for k=1:max(kend,1)]
         ProductFun{S,V,typeof(sp),T}(ret,sp)
     else
@@ -135,8 +139,8 @@ ProductFun(f::Function) = ProductFun(dynamic(f),ChebyshevInterval(),ChebyshevInt
 
 ## Conversion from other 2D Funs
 
-ProductFun(f::LowRankFun) = ProductFun(coefficients(f),space(f,1),space(f,2))
-ProductFun(f::Fun{S}) where {S<:AbstractProductSpace} = ProductFun(coefficientmatrix(f),space(f))
+ProductFun(f::LowRankFun; kw...) = ProductFun(coefficients(f),space(f,1),space(f,2); kw...)
+ProductFun(f::Fun{S}; kw...) where {S<:AbstractProductSpace} = ProductFun(coefficientmatrix(f), space(f); kw...)
 
 ## Conversion to other ProductSpaces with the same coefficients
 

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -430,14 +430,8 @@ function Base.getindex(K::KroneckerOperator, f::LowRankFun)
         op1[A] ⊗ op2[B]
     end
 end
-function Base.getindex(K::KroneckerOperator, B::ProductFun)
-    op1, op2 = K.ops
-    S2 = factors(B.space)[2]
-    T = cfstype(B)
-    sum(enumerate(B.coefficients)) do (ind, fi)
-        op1[fi] ⊗ op2[Fun(S2, [zeros(T, ind-1); one(T)])]
-    end
-end
+Base.getindex(K::KroneckerOperator, B::ProductFun) = K[LowRankFun(B)]
+
 for F in [:MultivariateFun, :ProductFun, :LowRankFun]
     for O in [:DerivativeWrapper, :DefiniteIntegralWrapper]
         @eval Base.getindex(K::$O{<:KroneckerOperator}, f::$F) = K.op[f]

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -450,7 +450,7 @@ end
 function (*)(ko::KroneckerOperator{<:Operator, <:ConstantOperator}, pf::ProductFun)
     O1, O2 = ko.ops
     O12 = O2.λ * O1
-    ProductFun(map(x -> O12*x, pf.coefficients), pf.space)
+    ProductFun(map(x -> O12*x, pf.coefficients), factors(pf.space)[2])
 end
 
 function (*)(ko::KroneckerOperator, lrf::LowRankFun)

--- a/src/PDE/PDE.jl
+++ b/src/PDE/PDE.jl
@@ -53,7 +53,6 @@ end
 # consistent with treating it as an expansion in the second space
 # We re-route through _mulop to distinguish between operators on UnivariateSpace and
 # those on BivariateSpace
-_mulop(O::Operator, ::Space, ::ProductFun) = error("define $(typeof(O)) * ProductFun")
 function _mulop(B::Operator, ::UnivariateSpace, f::ProductFun)
     if isafunctional(B)
         Fun(factor(space(f),2),map(c->Number(B*c),f.coefficients))

--- a/src/PDE/PDE.jl
+++ b/src/PDE/PDE.jl
@@ -49,13 +49,18 @@ function timedirichlet(d::Union{ProductDomain,TensorSpace})
 end
 
 
-
-function *(B::Operator,f::ProductFun)
+# Operators on an univariate space may act on the second space of the ProductFun,
+# consistent with treating it as an expansion in the second space
+# We re-route through _mulop to distinguish between operators on UnivariateSpace and
+# those on BivariateSpace
+_mulop(O::Operator, ::Space, ::ProductFun) = error("define $(typeof(O)) * ProductFun")
+function _mulop(B::Operator, ::UnivariateSpace, f::ProductFun)
     if isafunctional(B)
         Fun(factor(space(f),2),map(c->Number(B*c),f.coefficients))
     else
         ProductFun(space(f),map(c->B*c,f.coefficients))
     end
 end
+*(B::Operator,f::ProductFun) = _mulop(B, domainspace(B), f)
 
 *(f::ProductFun,B::Operator) = transpose(B*(transpose(f)))

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -552,9 +552,9 @@ transform!(S::Space,cfs) = plan_transform!(S,cfs)*cfs
 
 _coefficients!!(::Val{true}) = coefficients!
 _coefficients!!(::Val{false}) = coefficients
-_mul(P::CanonicalTransformPlan, ip, vals) = _coefficients!!(ip)(P.plan * vals, P.canonicalspace, P.space)
-_mul(P::ICanonicalTransformPlan, ip, cfs) = P.plan * _coefficients!!(ip)(cfs, P.space, P.canonicalspace)
-*(P::Union{CanonicalTransformPlan, ICanonicalTransformPlan}, vals::AbstractVector) = _mul(P, Val(inplace(P)), vals)
+_multransform(P::CanonicalTransformPlan, ip, vals) = _coefficients!!(ip)(P.plan * vals, P.canonicalspace, P.space)
+_multransform(P::ICanonicalTransformPlan, ip, cfs) = P.plan * _coefficients!!(ip)(cfs, P.space, P.canonicalspace)
+*(P::Union{CanonicalTransformPlan, ICanonicalTransformPlan}, vals::AbstractVector) = _multransform(P, Val(inplace(P)), vals)
 
 
 for OP in (:plan_transform,:plan_itransform,:plan_transform!,:plan_itransform!)


### PR DESCRIPTION
Specialize the action of certain operators using the structures of `LowRankFun` or `ProductFun`, instead of casting everything to `Fun` first