### PR TITLE
improve in inference in mulvar ops

### DIFF
--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -271,7 +271,7 @@ function Derivative(S::TensorSpace{SV,DD}, order) where {SV,DD<:EuclideanDomain{
         T=promote_type(eltype(Dx),eltype(Dy))
     end
     # try to work around type inference
-    DerivativeWrapper{typeof(K),typeof(domainspace(K)),Vector{Int},T}(K,order)
+    DerivativeWrapper{typeof(K),typeof(S),Vector{Int},T}(K,order)
 end
 
 

--- a/src/PDE/PDE.jl
+++ b/src/PDE/PDE.jl
@@ -13,7 +13,7 @@ function Laplacian(d::BivariateSpace,k::Integer)
     Dx2=Derivative(d, Vec{2}(2,0))
     Dy2=Derivative(d, Vec{2}(0,2))
     if k==1
-        LaplacianWrapper(Dx2+Dy2,k)
+        LaplacianWrapper(Dx2+Dy2,d,k)
     else
         @assert k > 0
         Δ=Laplacian(d,1)


### PR DESCRIPTION
This slightly improves inference in certain operator constructions. The type parameter `S` in wrapper ops seems to not be linked to anything, so I'm not sure what tests to add for this.