### PR TITLE
make `grad` consistent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.25"
+version = "0.7.26"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/PDE/PDE.jl
+++ b/src/PDE/PDE.jl
@@ -28,7 +28,7 @@ function grad(d::BivariateSpace)
     @assert n == 2 "grad for n>2 is not implemented"
     Vec{2}(Derivative(d, Vec{2}(1,0)), Derivative(d, Vec{2}(0,1)))
 end
-grad(f::Fun{<:BivariateSpace}) = Fun(grad(space(f)) * f)
+grad(f::Fun{<:BivariateSpace}) = grad(space(f)) * f
 
 function tensor_Dirichlet(d::Union{ProductDomain,TensorSpace},k)
     @assert nfactors(d)==2


### PR DESCRIPTION
Fix `grad(f)` to make the following consistent:
```julia
julia> f = Fun((x,y)->x^2*y^2, Chebyshev()^2);

julia> grad(f) == grad(space(f)) * f
true
```
TBH the fix should be in the other direction, with `grad(space(f)) * f` returning a `Fun`, so I'm uncertain if this PR is the right direction.