### PR TITLE
Fix convert for ConcreteOperatorFunction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.27"
+version = "0.7.28"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/general/OperatorFunction.jl
+++ b/src/Operators/general/OperatorFunction.jl
@@ -9,7 +9,7 @@ struct ConcreteOperatorFunction{BT<:Operator,FF,T} <: OperatorFunction{BT,FF,T}
 end
 
 ConcreteOperatorFunction(op::Operator,f::Function) =
-    ConcreteOperatorFunction{typeof(op),typeof(f),eltype(op)}(op,f)
+    ConcreteOperatorFunction{typeof(op),typeof(f),float(eltype(op))}(op,f)
 OperatorFunction(op::Operator,f::Function) = ConcreteOperatorFunction(op,f)
 
 for op in (:domainspace,:rangespace,:domain,:bandwidths)
@@ -31,7 +31,8 @@ function convert(::Type{Operator{T}},D::ConcreteOperatorFunction) where T
     if T==eltype(D)
         D
     else
-        ConcreteOperatorFunction{typeof(D.op),T}(D.op,D.f)
+        DopT = strictconvert(Operator{T}, D.op)
+        ConcreteOperatorFunction(DopT, D.f)::Operator{T}
     end
 end
 

--- a/src/Operators/general/OperatorFunction.jl
+++ b/src/Operators/general/OperatorFunction.jl
@@ -8,8 +8,10 @@ struct ConcreteOperatorFunction{BT<:Operator,FF,T} <: OperatorFunction{BT,FF,T}
     f::FF
 end
 
-ConcreteOperatorFunction(op::Operator,f::Function) =
-    ConcreteOperatorFunction{typeof(op),typeof(f),float(eltype(op))}(op,f)
+function ConcreteOperatorFunction(op::Operator,f::Function)
+    T = typeof(f(oneunit(eltype(op))))
+    ConcreteOperatorFunction{typeof(op),typeof(f),T}(op,f)
+end
 OperatorFunction(op::Operator,f::Function) = ConcreteOperatorFunction(op,f)
 
 for op in (:domainspace,:rangespace,:domain,:bandwidths)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -171,6 +171,13 @@ using LinearAlgebra
             P = PartialInverseOperator(C)
             @test AbstractMatrix(P * C) == I(size(C,1))
         end
+
+        @testset "ConcreteOperatorFunction" begin
+            A = 2I : PointSpace(1:4)
+            Ainv = inv(A)
+            B = convert(Operator{ComplexF64}, Ainv)
+            @test ComplexF64.(Ainv[1:4, 1:4]) == B[1:4, 1:4]
+        end
     end
 
     @testset "DiracSpace" begin

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -176,6 +176,7 @@ using LinearAlgebra
             A = 2I : PointSpace(1:4)
             Ainv = inv(A)
             B = convert(Operator{ComplexF64}, Ainv)
+            @test B isa Operator{ComplexF64}
             @test ComplexF64.(Ainv[1:4, 1:4]) == B[1:4, 1:4]
         end
     end


### PR DESCRIPTION
After this PR
```julia
julia> A = 2I : Chebyshev()
ConstantOperator : Chebyshev() → Chebyshev()
 2    ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  ⋅
  ⋅  2    ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  ⋅
  ⋅   ⋅  2    ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  ⋅
  ⋅   ⋅   ⋅  2    ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  ⋅
  ⋅   ⋅   ⋅   ⋅  2    ⋅   ⋅   ⋅   ⋅   ⋅  ⋅
  ⋅   ⋅   ⋅   ⋅   ⋅  2    ⋅   ⋅   ⋅   ⋅  ⋅
  ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  2    ⋅   ⋅   ⋅  ⋅
  ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  2    ⋅   ⋅  ⋅
  ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  2    ⋅  ⋅
  ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  2   ⋅
  ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅   ⋅  ⋱

julia> inv(A)
ConcreteOperatorFunction : Chebyshev() → Chebyshev()
 0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   0.5   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   0.5   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱

julia> convert(Operator{ComplexF64}, inv(A))
ConcreteOperatorFunction : Chebyshev() → Chebyshev()
 0.5-0.0im      ⋅          ⋅      …      ⋅          ⋅          ⋅      ⋅
     ⋅      0.5-0.0im      ⋅             ⋅          ⋅          ⋅      ⋅
     ⋅          ⋅      0.5-0.0im         ⋅          ⋅          ⋅      ⋅
     ⋅          ⋅          ⋅             ⋅          ⋅          ⋅      ⋅
     ⋅          ⋅          ⋅             ⋅          ⋅          ⋅      ⋅
     ⋅          ⋅          ⋅      …      ⋅          ⋅          ⋅      ⋅
     ⋅          ⋅          ⋅             ⋅          ⋅          ⋅      ⋅
     ⋅          ⋅          ⋅         0.5-0.0im      ⋅          ⋅      ⋅
     ⋅          ⋅          ⋅             ⋅      0.5-0.0im      ⋅      ⋅
     ⋅          ⋅          ⋅             ⋅          ⋅      0.5-0.0im  ⋅
     ⋅          ⋅          ⋅      …      ⋅          ⋅          ⋅      ⋱
```
Both the second and the third are broken on master at present.