### PR TITLE
Use `nameof` in show

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -30,7 +30,7 @@ end
 
 ## Operator
 
-summarystr(B::Operator) = string(typeof(B).name.name, " : ", domainspace(B), " → ", rangespace(B))
+summarystr(B::Operator) = string(nameof(typeof(B)), " : ", domainspace(B), " → ", rangespace(B))
 summary(io::IO, B::Operator) = print(io, summarystr(B))
 
 struct PrintShow

--- a/test/show.jl
+++ b/test/show.jl
@@ -51,5 +51,10 @@
 			s = String(take!(io))
 			@test startswith(s, "ConstantSpace(0..1) /")
 		end
+		@testset "ConstantOperator" begin
+			A = I : PointSpace(1:4)
+			s = summary(A)
+			@test startswith(s, "ConstantOperator")
+		end
 	end
 end


### PR DESCRIPTION
Avoid using `T.name.name` when `nameof` does exactly that