### PR TITLE
Clean up `strictconvert` usage

### DIFF
--- a/src/onehotvector.jl
+++ b/src/onehotvector.jl
@@ -15,7 +15,7 @@ function Base.getindex(v::OneHotVector{T}, i::Int) where {T}
 	i == v.n ? one(T) : zero(T)
 end
 # assume that the basis label starts at zero
-function basisfunction(sp, k)
-	k >= 0 || throw(ArgumentError("basis label must be non-negative, received $k"))
-	Fun(sp, OneHotVector(k))
+function basisfunction(sp, oneindex)
+	oneindex >= 0 || throw(ArgumentError("index to set to one must be non-negative, received $oneindex"))
+	Fun(sp, OneHotVector(oneindex))
 end

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -433,7 +433,8 @@ end
 
 for OP in (:<,:(Base.isless),:(<=))
     @eval begin
-        $OP(a::Fun{<:ConstantSpace},b::Fun{<:ConstantSpace}) = $OP(strictconvert(Number,a),Number(b))
+        $OP(a::Fun{<:ConstantSpace},b::Fun{<:ConstantSpace}) =
+            $OP(strictconvert(Number,a), strictconvert(Number, b))
         $OP(a::Fun{<:ConstantSpace},b::Number) = $OP(strictconvert(Number,a),b)
         $OP(a::Number,b::Fun{<:ConstantSpace}) = $OP(a,strictconvert(Number,b))
     end
@@ -479,8 +480,8 @@ for op in (:(argmax),:(argmin))
             pts = extremal_args(f)
             # the extra real avoids issues with complex round-off
             v = map(real∘f, pts)::Vector
-            x = pts[strictconvert(Int, $op(v))::Int]
-            strictconvert(T, x)::T
+            x = pts[strictconvert(Int, $op(v))]
+            strictconvert(T, x)
         end
 
         function $op(f::Fun)
@@ -493,7 +494,7 @@ for op in (:(argmax),:(argmin))
             fp = map(f, pts)
             @assert norm(imag(fp))<100eps()
             v = real(fp)::Vector
-            x = pts[strictconvert(Int, $op(v))::Int]
+            x = pts[strictconvert(Int, $op(v))]
             strictconvert(T, x)
         end
     end


### PR DESCRIPTION
Change usage such as `strictconvert(T, x)::T` to `strictconvert(T, x)`