### PR TITLE
Move calculus functions from `ApproxFun`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.29"
+version = "0.7.30"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/Multivariate.jl
+++ b/src/Multivariate/Multivariate.jl
@@ -13,9 +13,13 @@ differentiate(u::BivariateFun,i::Integer,j::Integer) =
     j==0 ? u : differentiate(differentiate(u,i),i,j-1)
 grad(u::BivariateFun) = [differentiate(u,1),differentiate(u,2)]
 lap(u::BivariateFun) = differentiate(u,1,2)+differentiate(u,2,2)
-Base.div(u::AbstractVector{B}) where {B<:BivariateFun} =
+Base.div(u::AbstractVector{<:BivariateFun}) =
     differentiate(u[1],1)+differentiate(u[2],2)
 curl(u::AbstractVector{B}) where {B<:BivariateFun} = differentiate(u[2],1)-differentiate(u[1],2)
+
+∇(F::MultivariateFun) = grad(F)
+LinearAlgebra.dot(::typeof(∇), F::Vector{<:MultivariateFun}) = div(F)
+LinearAlgebra.cross(::typeof(∇), F::Vector{<:MultivariateFun}) = curl(F)
 
 Base.chop(f::MultivariateFun) = chop(f,10eps())
 cfstype(::MultivariateFun{T}) where {T} = T

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -166,7 +166,13 @@ function linesum(f::Fun)
     end
 end
 
+∫(f::Fun)=integrate(f)
 
+⨜(f::Fun)=cumsum(f)
+
+for OP in (:Σ,:∮,:⨍,:⨎)
+    @eval $OP(f::Fun)=sum(f)
+end
 
 
 # Multivariate
@@ -371,3 +377,7 @@ Return the laplacian operator on an unset space.
 Spaces will be inferred when applying or manipulating the operator.
 """
 Laplacian()
+
+
+const 𝒟 = Derivative()
+const Δ = Laplacian()


### PR DESCRIPTION
Move methods like `dot` and `cross` for `∇` over to this package.