### PR TITLE
Tuples in _vcat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.30"
+version = "0.7.31"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -451,15 +451,12 @@ operators(A::Operator) = [A]
 
 Base.vcat(A::MatrixInterlaceOperator...) =
     InterlaceOperator(vcat(map(operators,A)...))
+
+__vcat(a::VectorInterlaceOperator, b::OperatorTypes...) = (a.ops..., __vcat(b...)...)
+__vcat(a::OperatorTypes, b::OperatorTypes...) = (a, __vcat(b...)...)
+__vcat() = ()
 function _vcat(A::OperatorTypes...)
-    Av = Vector{Operator{mapreduce(eltype,promote_type,A)}}()
-    for a in A
-        if a isa VectorInterlaceOperator
-            append!(Av,a.ops)
-        else
-            push!(Av,a)
-        end
-    end
+    Av = __vcat(A...)
     InterlaceOperator(vnocat(Av...))
 end
 


### PR DESCRIPTION
This helps marginally with type-stability

On master
```julia
julia> @code_warntype [Derivative(); Dirichlet()]
MethodInstance for vcat(::ApproxFunBase.ConcreteDerivative{ApproxFunBase.UnsetSpace, Int64, ApproxFunBase.UnsetNumber}, ::ApproxFunBase.DirichletWrapper{ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1, ApproxFunBase.UnsetSpace, ApproxFunBase.ArraySpace{ApproxFunBase.UnsetSpace, 1, ApproxFunBase.AnyDomain, ApproxFunBase.UnsetNumber}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, Tuple{Infinities.RealInfinity, Infinities.InfiniteCardinal{0}}}, ApproxFunBase.UnsetNumber})
  from vcat(A::Operator, B::Union{Number, Fun, Operator, UniformScaling}...) in ApproxFunBase at /home/jb6888/Dropbox/JuliaPackages/ApproxFunBase/src/Operators/general/InterlaceOperator.jl:483
Arguments
  #self#::Core.Const(vcat)
  A::ApproxFunBase.ConcreteDerivative{ApproxFunBase.UnsetSpace, Int64, ApproxFunBase.UnsetNumber}
  B::Tuple{ApproxFunBase.DirichletWrapper{ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1, ApproxFunBase.UnsetSpace, ApproxFunBase.ArraySpace{ApproxFunBase.UnsetSpace, 1, ApproxFunBase.AnyDomain, ApproxFunBase.UnsetNumber}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, Tuple{Infinities.RealInfinity, Infinities.InfiniteCardinal{0}}}, ApproxFunBase.UnsetNumber}}
Body::Any
1 ─ %1 = Core.tuple(A)::Tuple{ApproxFunBase.ConcreteDerivative{ApproxFunBase.UnsetSpace, Int64, ApproxFunBase.UnsetNumber}}
│   %2 = Core._apply_iterate(Base.iterate, ApproxFunBase._vcat, %1, B)::Any
└──      return %2
```

PR
```julia
julia> @code_warntype [Derivative(); Dirichlet()]
MethodInstance for vcat(::ApproxFunBase.ConcreteDerivative{ApproxFunBase.UnsetSpace, Int64, ApproxFunBase.UnsetNumber}, ::ApproxFunBase.DirichletWrapper{ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1, ApproxFunBase.UnsetSpace, ApproxFunBase.ArraySpace{ApproxFunBase.UnsetSpace, 1, ApproxFunBase.AnyDomain, ApproxFunBase.UnsetNumber}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, Tuple{Infinities.RealInfinity, Infinities.InfiniteCardinal{0}}}, ApproxFunBase.UnsetNumber})
  from vcat(A::Operator, B::Union{Number, Fun, Operator, UniformScaling}...) in ApproxFunBase at /home/jb6888/Dropbox/JuliaPackages/ApproxFunBase/src/Operators/general/InterlaceOperator.jl:480
Arguments
  #self#::Core.Const(vcat)
  A::ApproxFunBase.ConcreteDerivative{ApproxFunBase.UnsetSpace, Int64, ApproxFunBase.UnsetNumber}
  B::Tuple{ApproxFunBase.DirichletWrapper{ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1, ApproxFunBase.UnsetSpace, ApproxFunBase.ArraySpace{ApproxFunBase.UnsetSpace, 1, ApproxFunBase.AnyDomain, ApproxFunBase.UnsetNumber}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, ApproxFunBase.CachedIterator{Tuple{Int64, Int64}, ApproxFunBase.BlockInterlacer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}}, Tuple{Infinities.RealInfinity, Infinities.InfiniteCardinal{0}}}, ApproxFunBase.UnsetNumber}}
Body::ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1}
1 ─ %1 = Core.tuple(A)::Tuple{ApproxFunBase.ConcreteDerivative{ApproxFunBase.UnsetSpace, Int64, ApproxFunBase.UnsetNumber}}
│   %2 = Core._apply_iterate(Base.iterate, ApproxFunBase._vcat, %1, B)::ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1}
└──      return %2
```

So the inferred type goes from `Any` to `ApproxFunBase.InterlaceOperator{ApproxFunBase.UnsetNumber, 1}`