### PR TITLE
Tuples in promotespaces

### DIFF
--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -51,9 +51,9 @@ function rangespace(A::AbstractVector{T}) where T<:Operator
     Space(spl)
 end
 
-promotespaces(A::AbstractMatrix{T}) where {T<:Operator} = promotespaces(Matrix(A))
+promotespaces(A::AbstractMatrix{<:Operator}) = promotespaces(Matrix(A))
 
-function promotespaces(A::Matrix{T}) where T<:Operator
+function promotespaces(A::Matrix{<:Operator})
     isempty(A) && return A
     ret = similar(A) #TODO: promote might have different Array type
     for j=1:size(A,2)

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -86,23 +86,23 @@ promotedomainspace(P::Operator,sp::Space,cursp::Space) =
 
 
 
+const VectorOrTupleOfOp{O<:Operator} = Union{AbstractVector{O}, Tuple{O, Vararg{O}}}
 
-
-function promoterangespace(ops::Union{AbstractVector{O}, Tuple{O,Vararg{O}}}) where O<:Operator
+function promoterangespace(ops::VectorOrTupleOfOp{O}) where O<:Operator
     isempty(ops) && return strictconvert(Vector{Operator{eltype(O)}}, ops)
     k=findmaxrangespace(ops)
     #TODO: T might be incorrect
     T=mapreduce(eltype,promote_type,ops)
     Operator{T}[promoterangespace(op,k) for op in ops]
 end
-function promotedomainspace(ops::Union{AbstractVector{O}, Tuple{O,Vararg{O}}}) where O<:Operator
+function promotedomainspace(ops::VectorOrTupleOfOp{O}) where O<:Operator
     isempty(ops) && return strictconvert(Vector{Operator{eltype(O)}}, ops)
     k=findmindomainspace(ops)
     #TODO: T might be incorrect
     T=mapreduce(eltype,promote_type,ops)
     Operator{T}[promotedomainspace(op,k) for op in ops]
 end
-function promotedomainspace(ops::Union{AbstractVector{O}, Tuple{O,Vararg{O}}},S::Space) where O<:Operator
+function promotedomainspace(ops::VectorOrTupleOfOp{O}, S::Space) where O<:Operator
     isempty(ops) && return strictconvert(Vector{Operator{eltype(O)}}, ops)
     k=conversion_type(findmindomainspace(ops),S)
     #TODO: T might be incorrect
@@ -158,8 +158,8 @@ spacescompatible(A::Operator,B::Operator) =
 
 
 #It's important that domain space is promoted first as it might impact range space
-promotespaces(ops::AbstractVector) = promoterangespace(promotedomainspace(ops))
-function promotespaces(ops::AbstractVector,b::Fun)
+promotespaces(ops::VectorOrTupleOfOp{<:Operator}) = promoterangespace(promotedomainspace(ops))
+function promotespaces(ops::VectorOrTupleOfOp{<:Operator}, b::Fun)
     A=promotespaces(ops)
     if isa(rangespace(A),AmbiguousSpace)
         # try setting the domain space

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,6 +287,12 @@ end
         @test Ar[1:4, 1:4] == diagm(0=>fill(3, 4))
         @test Ai[1:4, 1:4] == diagm(0=>fill(-2, 4))
     end
+    @testset "tuples in promotespaces" begin
+        M = Multiplication(Fun(PointSpace(1:4)), PointSpace(1:4))
+        A = ApproxFunBase.promotespaces([M, M])
+        B = ApproxFunBase.promotespaces((M, M))
+        @test all(((x,y),) -> x == y, zip(A, B))
+    end
 end
 
 @testset "RowVector" begin


### PR DESCRIPTION
After this, the following are equivalent:
```julia
julia> M = Multiplication(Fun())
ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> ApproxFunBase.promotespaces([M,M])
2-element Vector{Operator{Float64}}:
 ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()
 ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()

julia> ApproxFunBase.promotespaces((M,M))
2-element Vector{Operator{Float64}}:
 ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()
 ConcreteMultiplication : ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace()
```