### PR TITLE
Optionally skip InterlaceOp domain promote

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.31"
+version = "0.7.32"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/functionals/Evaluation.jl
+++ b/src/Operators/functionals/Evaluation.jl
@@ -182,7 +182,8 @@ convert(::Type{Operator{T}},B::DirichletWrapper) where {T} =
     DirichletWrapper(Operator{T}(B.op),B.order)::Operator{T}
 
 # Default is to use diffbca
-default_Dirichlet(sp::Space,λ) = DirichletWrapper([ldiffbc(sp,λ);rdiffbc(sp,λ)],λ)
+default_Dirichlet(sp::Space,λ) =
+    DirichletWrapper(InterlaceOperator((ldiffbc(sp,λ), rdiffbc(sp,λ)), false), λ)
 Dirichlet(sp::Space,λ) = default_Dirichlet(sp,λ)
 Dirichlet(sp::Space) = Dirichlet(sp,0)
 Dirichlet() = Dirichlet(UnsetSpace())

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -186,9 +186,18 @@ function InterlaceOperator(opsin::AbstractVector{<:Operator})
     ops = _convert_vector(promotedomainspace(opsin))
     InterlaceOperator(ops, domainspace(first(ops)), rangespace(ops))
 end
-function InterlaceOperator(opsin::Tuple{Operator, Vararg{Operator}})
-    ops = promotedomainspace(opsin)
+@inline function _InterlaceOperator(opsin, promotedomain)
+    ops = promotedomain ? promotedomainspace(opsin) : opsin
     InterlaceOperator(ops, domainspace(first(ops)), rangespace(ops))
+end
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive function InterlaceOperator(opsin::Tuple{Operator, Vararg{Operator}}, promotedomain = true)
+        _InterlaceOperator(opsin, promotedomain)
+    end
+else
+    function InterlaceOperator(opsin::Tuple{Operator, Vararg{Operator}}, promotedomain = true)
+        _InterlaceOperator(opsin, promotedomain)
+    end
 end
 
 InterlaceOperator(ops::AbstractArray) =


### PR DESCRIPTION
Inference in often terrible in `promotedomainspace`, so we may choose to skip this in cases where the domain doesn't need to be promoted. After this, the following is type-stable:
```julia
julia> @inferred (r -> Dirichlet(r, 1))(Chebyshev(-1..1))
DirichletWrapper : Chebyshev(-1..1) → 2-element ArraySpace:
ConstantSpace{DomainSets.Point{Int64}, Float64}[ConstantSpace(Point(-1)), ConstantSpace(Point(1))]
 0.0  1.0  -4.0  9.0  -16.0  25.0  -36.0  49.0  -64.0  81.0  ⋯
 0.0  1.0   4.0  9.0   16.0  25.0   36.0  49.0   64.0  81.0  ⋯
```