### PR TITLE
PlusOp in TensorSpace Multiplication

### DIFF
--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -402,9 +402,11 @@ Conversion(a::TensorSpace,b::TensorSpace) = ConversionWrapper(promote_type(prect
 
 
 
-function Multiplication(f::Fun{TS},S::TensorSpace) where {TS<:TensorSpace}
-    lr=LowRankFun(f)
-    ops=map(kron,map(a->Multiplication(a,S.spaces[1]),lr.A),map(a->Multiplication(a,S.spaces[2]),lr.B))
+function Multiplication(f::Fun{<:TensorSpace}, S::TensorSpace)
+    lr = LowRankFun(f)
+    MAs = map(a->Multiplication(a,S.spaces[1]), lr.A)
+    MBs = map(a->Multiplication(a,S.spaces[2]), lr.B)
+    ops = map(kron, MAs, MBs)
     MultiplicationWrapper(f, PlusOperator(ops))
 end
 

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -405,7 +405,7 @@ Conversion(a::TensorSpace,b::TensorSpace) = ConversionWrapper(promote_type(prect
 function Multiplication(f::Fun{TS},S::TensorSpace) where {TS<:TensorSpace}
     lr=LowRankFun(f)
     ops=map(kron,map(a->Multiplication(a,S.spaces[1]),lr.A),map(a->Multiplication(a,S.spaces[2]),lr.B))
-    MultiplicationWrapper(f,+(ops...))
+    MultiplicationWrapper(f, PlusOperator(ops))
 end
 
 ## Functionals


### PR DESCRIPTION
This improves inference in `Multiplication(f::Fun{<:TensorSpace}, S::TensorSpace)`, as `+(ops...)` can be poorly inferred.