### PR TITLE
Use `SVector` instead of `Vec`

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -8,7 +8,7 @@ export components, component, ncomponents
 # add indexing for all spaces, not just DirectSumSpace
 # mimicking scalar vs vector
 
-# prectype gives the precision, including for Vec
+# prectype gives the precision, including for SVector
 prectype(::Type{D}) where {D<:Domain} = float(eltype(eltype(D)))
 prectype(d::Domain) = prectype(typeof(d))
 
@@ -154,8 +154,8 @@ boundary(d::SegmentDomain) = [leftendpoint(d),rightendpoint(d)] #TODO: Points do
 
 ## map domains
 # we auto vectorize arguments
-tocanonical(d::Domain,x,y,z...) = tocanonical(d,Vec(x,y,z...))
-fromcanonical(d::Domain,x,y,z...) = fromcanonical(d,Vec(x,y,z...))
+tocanonical(d::Domain,x,y,z...) = tocanonical(d,SVector(x,y,z...))
+fromcanonical(d::Domain,x,y,z...) = fromcanonical(d,SVector(x,y,z...))
 
 
 mappoint(d1::Domain,d2::Domain,x...) = fromcanonical(d2,tocanonical(d1,x...))

--- a/src/Domains/ProductDomain.jl
+++ b/src/Domains/ProductDomain.jl
@@ -9,8 +9,8 @@ canonicaldomain(d::ProductDomain) = ProductDomain(map(canonicaldomain,factors(d)
 # product domains are their own canonical domain
 for OP in (:fromcanonical,:tocanonical)
     @eval begin
-        $OP(d::ProductDomain, x::Vec) = Vec(map($OP,factors(d),x)...)
-        $OP(d::ProductDomain, x::Vec{2}) = Vec($OP(first(factors(d)), first(x)), $OP(last(factors(d)), last(x)))
+        $OP(d::ProductDomain, x::SVector) = SVector(map($OP,factors(d),x)...)
+        $OP(d::ProductDomain, x::SVector{2}) = SVector($OP(first(factors(d)), first(x)), $OP(last(factors(d)), last(x)))
     end
 end
 
@@ -18,7 +18,7 @@ end
 
 function pushappendpts!(ret, xx, pts)
     if isempty(pts)
-        push!(ret,Vec(xx...))
+        push!(ret,SVector(xx...))
     else
         for x in pts[1]
             pushappendpts!(ret,(xx...,x...),pts[2:end])
@@ -29,7 +29,7 @@ end
 
 function checkpoints(d::ProductDomain)
     pts = checkpoints.(factors(d))
-    ret=Vector{Vec{sum(dimension.(factors(d))),float(promote_type(eltype.(eltype.(factors(d)))...))}}(undef, 0)
+    ret=Vector{SVector{sum(dimension.(factors(d))),float(promote_type(eltype.(eltype.(factors(d)))...))}}(undef, 0)
 
     pushappendpts!(ret,(),pts)
     ret
@@ -38,8 +38,8 @@ end
 function points(d::ProductDomain,n::Tuple)
     @assert length(factors(d)) == length(n)
     pts=map(points,factors(d),n)
-    ret=Vector{Vec{length(factors(d)),mapreduce(eltype,promote_type,factors(d))}}(undef, 0)
-    pushappendpts!(ret,Vec(x),pts)
+    ret=Vector{SVector{length(factors(d)),mapreduce(eltype,promote_type,factors(d))}}(undef, 0)
+    pushappendpts!(ret,SVector(x),pts)
     ret
 end
 

--- a/src/Domains/Segment.jl
+++ b/src/Domains/Segment.jl
@@ -25,7 +25,7 @@ Segment(a::Integer, b::Integer) = Segment(Float64(a),Float64(b)) #convenience me
 Segment(a::Complex{IT}, b) where {IT<:Integer} = Segment(ComplexF64(a),b) #convenience method
 Segment(a, b::Complex{IT}) where {IT<:Integer} = Segment(a,ComplexF64(b)) #convenience method
 Segment(a, b) = Segment{promote_type(typeof(a),typeof(b))}(a,b)
-Segment(a::Tuple, b::Tuple) = Segment(Vec(a...),Vec(b...))
+Segment(a::Tuple, b::Tuple) = Segment(SVector(a...),SVector(b...))
 
 
 convert(::Type{Domain{T}}, d::Segment) where {T<:Number} = Segment{T}(leftendpoint(d),rightendpoint(d))
@@ -89,7 +89,7 @@ mobius(d::IntervalOrSegment,x) = (2x - leftendpoint(d) - rightendpoint(d))/compl
 tocanonical(d::IntervalOrSegment{T},x) where {T<:Real} = mobius(d,x)
 tocanonicalD(d::IntervalOrSegment{T},x) where {T<:Real} = 2/complexlength(d)
 fromcanonical(d::IntervalOrSegment{T},x) where {T<:Number} = mean(d) + complexlength(d)x/2
-fromcanonical(d::IntervalOrSegment{T},x) where {T<:Vec} = mean(d) + complexlength(d)x/2
+fromcanonical(d::IntervalOrSegment{T},x) where {T<:SVector} = mean(d) + complexlength(d)x/2
 fromcanonicalD(d::IntervalOrSegment,x) = complexlength(d) / 2
 
 

--- a/src/Domains/multivariate.jl
+++ b/src/Domains/multivariate.jl
@@ -6,11 +6,11 @@ include("ProductDomain.jl")
 const RectDomain = Union{DomainSets.FixedIntervalProduct{2}, DomainSets.Rectangle, VcatDomain{2,<:Any,(1,1),<:Tuple}}
 
 boundary(d::RectDomain) =
-    PiecewiseSegment([Vec(leftendpoint(factor(d,1)),leftendpoint(factor(d,2))),
-                      Vec(rightendpoint(factor(d,1)),leftendpoint(factor(d,2))),
-                      Vec(rightendpoint(factor(d,1)),rightendpoint(factor(d,2))),
-                      Vec(leftendpoint(factor(d,1)),rightendpoint(factor(d,2))),
-                      Vec(leftendpoint(factor(d,1)),leftendpoint(factor(d,2)))])
+    PiecewiseSegment([SVector(leftendpoint(factor(d,1)),leftendpoint(factor(d,2))),
+                      SVector(rightendpoint(factor(d,1)),leftendpoint(factor(d,2))),
+                      SVector(rightendpoint(factor(d,1)),rightendpoint(factor(d,2))),
+                      SVector(leftendpoint(factor(d,1)),rightendpoint(factor(d,2))),
+                      SVector(leftendpoint(factor(d,1)),leftendpoint(factor(d,2)))])
 
 
 ## Union

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -87,7 +87,7 @@ function Fun(sp::Space,v::AbstractVector{Any})
 end
 
 
-hasnumargs(f::Fun,k) = k == 1 || domaindimension(f) == k  # all funs take a single argument as a Vec
+hasnumargs(f::Fun,k) = k == 1 || domaindimension(f) == k  # all funs take a single argument as a SVector
 
 ##Coefficient routines
 #TODO: domainscompatible?
@@ -352,7 +352,7 @@ function evaluate(f::AbstractVector,S::Space,x...)
 end
 
 evaluate(f::Fun,x) = evaluate(f.coefficients,f.space,x)
-evaluate(f::Fun,x,y,z...) = evaluate(f.coefficients,f.space,Vec(x,y,z...))
+evaluate(f::Fun,x,y,z...) = evaluate(f.coefficients,f.space,SVector(x,y,z...))
 
 
 (f::Fun)(x...) = evaluate(f,x...)
@@ -390,7 +390,7 @@ julia> extrapolate(f, 2)
 ```
 """
 extrapolate(f::Fun,x) = extrapolate(f.coefficients,f.space,x)
-extrapolate(f::Fun,x,y,z...) = extrapolate(f.coefficients,f.space,Vec(x,y,z...))
+extrapolate(f::Fun,x,y,z...) = extrapolate(f.coefficients,f.space,SVector(x,y,z...))
 
 
 ##Data routines

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -35,7 +35,7 @@ hasnumargs(f,k) = k == 1 ? applicable(f, 0.0) : applicable(f, (1.0:k)...)
 
 # fast implementation of isapprox with atol a non-keyword argument in most cases
 isapprox_atol(a,b,atol;kwds...) = isapprox(a,b;atol=atol,kwds...)
-isapprox_atol(a::Vec,b::Vec,atol::Real=0;kwds...) = isapprox_atol(collect(a),collect(b),atol;kwds...)
+isapprox_atol(a::SVector,b::SVector,atol::Real=0;kwds...) = isapprox_atol(collect(a),collect(b),atol;kwds...)
 function isapprox_atol(x::Number, y::Number, atol::Real=0; rtol::Real=Base.rtoldefault(x,y))
     x == y || (isfinite(x) && isfinite(y) && abs(x-y) <= atol + rtol*max(abs(x), abs(y)))
 end
@@ -60,8 +60,8 @@ real(x...) = Base.real(x...)
 real(::Type{UnsetNumber}) = UnsetNumber
 real(::Type{Array{T,n}}) where {T<:Real,n} = Array{T,n}
 real(::Type{Array{T,n}}) where {T<:Complex,n} = Array{real(T),n}
-real(::Type{Vec{N,T}}) where {N,T<:Real} = Vec{N,T}
-real(::Type{Vec{N,T}}) where {N,T<:Complex} = Vec{N,real(T)}
+real(::Type{SVector{N,T}}) where {N,T<:Real} = SVector{N,T}
+real(::Type{SVector{N,T}}) where {N,T<:Complex} = SVector{N,real(T)}
 
 float(x) = Base.float(x)
 Base.float(::UnsetNumber) = UnsetNumber()
@@ -85,11 +85,11 @@ eps(z::Dual{Complex{T}}) where {T<:Real} = eps(abs(z))
 
 
 eps(::Type{Vector{T}}) where {T<:Number} = eps(T)
-eps(::Type{Vec{k,T}}) where {k,T<:Number} = eps(T)
+eps(::Type{SVector{k,T}}) where {k,T<:Number} = eps(T)
 
 
 isnan(x) = Base.isnan(x)
-isnan(x::Vec) = map(isnan,x)
+isnan(x::SVector) = map(isnan,x)
 
 
 # BLAS

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -534,7 +534,7 @@ function points(sp::TensorSpace,n)
 
     for y in points(b,M),
         x in points(a,N)
-        push!(pts,Vec(x...,y...))
+        push!(pts,SVector(x...,y...))
     end
     pts
 end
@@ -565,7 +565,7 @@ union_rule(a::TensorSpace,b::TensorSpace) = TensorSpace(map(union,a.spaces,b.spa
 ## Convert from 1D to 2D
 
 
-# function isconvertible{T,TT}(sp::Space{Segment{Vec{2,TT}},<:Real},ts::TensorSpace)
+# function isconvertible{T,TT}(sp::Space{Segment{SVector{2,TT}},<:Real},ts::TensorSpace)
 #     d1 = domain(sp)
 #     d2 = domain(ts)
 #     if d2
@@ -583,12 +583,12 @@ isconvertible(sp::UnivariateSpace,ts::TensorSpace{SV,D,R}) where {SV,D<:Euclidea
 #     f[1]*ones(ts).coefficients
 
 #
-# function coefficients(f::AbstractVector,sp::Space{IntervalOrSegment{Vec{2,TT}}},ts::TensorSpace{Tuple{S,V},D,R}) where {S,V<:ConstantSpace,D<:EuclideanDomain{2},R,TT} where {T<:Number}
+# function coefficients(f::AbstractVector,sp::Space{IntervalOrSegment{SVector{2,TT}}},ts::TensorSpace{Tuple{S,V},D,R}) where {S,V<:ConstantSpace,D<:EuclideanDomain{2},R,TT} where {T<:Number}
 #     a = domain(sp)
 #     b = domain(ts)
 #     # make sure we are the same domain. This will be replaced by isisomorphic
-#     @assert first(a) ≈ Vec(first(factor(b,1)),factor(b,2).x) &&
-#         last(a) ≈ Vec(last(factor(b,1)),factor(b,2).x)
+#     @assert first(a) ≈ SVector(first(factor(b,1)),factor(b,2).x) &&
+#         last(a) ≈ SVector(last(factor(b,1)),factor(b,2).x)
 #
 #     coefficients(f,sp,setdomain(factor(ts,1),a))
 # end
@@ -607,7 +607,7 @@ function coefficients(f::AbstractVector,sp::UnivariateSpace,ts::TensorSpace{SV,D
 end
 
 
-function isconvertible(sp::Space{Segment{Vec{2,TT}}},ts::TensorSpace{SV,D,R}) where {TT,SV,D<:EuclideanDomain{2},R}
+function isconvertible(sp::Space{Segment{SVector{2,TT}}},ts::TensorSpace{SV,D,R}) where {TT,SV,D<:EuclideanDomain{2},R}
     d1 = domain(sp)
     d2 = domain(ts)
     if length(ts.spaces) ≠ 2
@@ -625,7 +625,7 @@ function isconvertible(sp::Space{Segment{Vec{2,TT}}},ts::TensorSpace{SV,D,R}) wh
 end
 
 
-function coefficients(f::AbstractVector,sp::Space{Segment{Vec{2,TT}}},
+function coefficients(f::AbstractVector,sp::Space{Segment{SVector{2,TT}}},
                             ts::TensorSpace{SV,D,R}) where {TT,SV,D<:EuclideanDomain{2},R}
     @assert length(ts.spaces) == 2
     d1 = domain(sp)

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -176,7 +176,7 @@ function promotespaces(A::Operator,B::Operator)
     if spacescompatible(A,B)
         A,B
     else
-        tuple(Vec{2}(promotespaces(uniontypedvec(A,B)))...)
+        tuple(SVector{2}(promotespaces(uniontypedvec(A,B)))...)
     end
 end
 

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -411,8 +411,8 @@ function Multiplication(f::Fun{<:TensorSpace}, S::TensorSpace)
 end
 
 ## Functionals
-Evaluation(sp::TensorSpace,x::Vec) = EvaluationWrapper(sp,x,zeros(Int,length(x)),⊗(map(Evaluation,sp.spaces,x)...))
-Evaluation(sp::TensorSpace,x::Tuple) = Evaluation(sp,Vec(x...))
+Evaluation(sp::TensorSpace,x::SVector) = EvaluationWrapper(sp,x,zeros(Int,length(x)),⊗(map(Evaluation,sp.spaces,x)...))
+Evaluation(sp::TensorSpace,x::Tuple) = Evaluation(sp,SVector(x...))
 
 
 

--- a/src/PDE/PDE.jl
+++ b/src/PDE/PDE.jl
@@ -10,8 +10,8 @@ lap(f::Fun) = Laplacian()*f
 
 
 function Laplacian(d::BivariateSpace,k::Integer)
-    Dx2=Derivative(d, Vec{2}(2,0))
-    Dy2=Derivative(d, Vec{2}(0,2))
+    Dx2=Derivative(d, SVector{2}(2,0))
+    Dy2=Derivative(d, SVector{2}(0,2))
     if k==1
         LaplacianWrapper(Dx2+Dy2,d,k)
     else
@@ -26,7 +26,7 @@ grad(d::ProductDomain) = grad(Space(d))
 function grad(d::BivariateSpace)
     n = length(factors(d))
     @assert n == 2 "grad for n>2 is not implemented"
-    Vec{2}(Derivative(d, Vec{2}(1,0)), Derivative(d, Vec{2}(0,1)))
+    SVector{2}(Derivative(d, SVector{2}(1,0)), Derivative(d, SVector{2}(0,1)))
 end
 grad(f::Fun{<:BivariateSpace}) = grad(space(f)) * f
 

--- a/src/Space.jl
+++ b/src/Space.jl
@@ -642,7 +642,7 @@ space(f::AbstractArray{T}) where T<:Number = ArraySpace(ConstantSpace{T}(), size
 
 setdomain(A::ConstantSpace{DD,R}, d) where {DD,R} = ConstantSpace{typeof(d),R}(d)
 
-blocklengths(::ConstantSpace) = Vec(1)
+blocklengths(::ConstantSpace) = SVector(1)
 
 # Range type is Nothing since function evaluation is not defined
 struct SequenceSpace <: Space{PositiveIntegers,Nothing} end

--- a/src/Spaces/ArraySpace.jl
+++ b/src/Spaces/ArraySpace.jl
@@ -94,7 +94,7 @@ transform(AS::ArraySpace{SS,n},vals::AbstractVector{Array{V,n}}) where {SS,n,V} 
     transform(vec(AS),map(vec,vals))
 transform(AS::VectorSpace{SS},vals::AbstractVector{AV}) where {SS,AV<:AbstractVector} =
     transform(AS,map(Vector,vals))
-transform(AS::VectorSpace{SS},vals::AbstractVector{Vec{V,n}}) where {SS,n,V} =
+transform(AS::VectorSpace{SS},vals::AbstractVector{SVector{V,n}}) where {SS,n,V} =
     transform(AS,map(Vector,vals))
 
 function itransform(AS::VectorSpace,cfs::AbstractVector)

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -129,7 +129,7 @@ function getindex(C::ConcreteConversion{CS,S,T},k::Integer,j::Integer) where {CS
 end
 
 
-coefficients(f::AbstractVector,sp::ConstantSpace{Segment{Vec{2,TT}}},
+coefficients(f::AbstractVector,sp::ConstantSpace{Segment{SVector{2,TT}}},
              ts::TensorSpace{SV,DD}) where {TT,SV,DD<:EuclideanDomain{2}} =
     f[1]*ones(ts).coefficients
 coefficients(f::AbstractVector,sp::ConstantSpace{<:Domain{<:Number}},

--- a/src/Spaces/SubSpace.jl
+++ b/src/Spaces/SubSpace.jl
@@ -211,7 +211,7 @@ points(sp::SubSpace, n) = points(sp.space, n)
 points(sp::SubSpace) = points(sp, dimension(sp))
 
 
-coefficients(v::AbstractVector,::SubSpace{DS,IT,Segment{Vec{2,TT}}},::TensorSpace{SV,DD}) where {DS,IT,TT,SV,DD<:EuclideanDomain{2}} =
+coefficients(v::AbstractVector,::SubSpace{DS,IT,Segment{SVector{2,TT}}},::TensorSpace{SV,DD}) where {DS,IT,TT,SV,DD<:EuclideanDomain{2}} =
     error("Not callable, only defined for ambiguity errors.")
 coefficients(v::AbstractVector,::SubSpace{DS,IT,D},::TensorSpace{SV,DD}) where {DS,IT,D,SV,DD<:EuclideanDomain{2}} =
     error("Not callable, only defined for ambiguity errors.")

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -15,7 +15,7 @@ valsdomain_type_promote(::Type{T},::Type{V}) where {T,V}=promote_type(T,V),promo
 
 
 function choosefuncfstype(ftype,Td)
-    if !( ftype<: Number || ( ((ftype <: AbstractArray) || (ftype <: Vec)) &&
+    if !( ftype<: Number || ( ((ftype <: AbstractArray) || (ftype <: SVector)) &&
                               (eltype(ftype) <: Number) ) )
         @warn "Function outputs type $(ftype), which is not a Number"
     end

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -1,6 +1,6 @@
 using ApproxFunBase
 using Test
-using ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, Vec, checkpoints
+using ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, SVector, checkpoints
 using StaticArrays
 using BandedMatrices: rowrange, colrange, BandedMatrix
 using LinearAlgebra
@@ -241,18 +241,18 @@ using LinearAlgebra
         a = HeavisideSpace(0:0.25:1)
         @test @inferred(dimension(a^2)) == dimension(a)^2
         @test @inferred(domain(a^2)) == domain(a)^2
-        @test @inferred(points(a^2)) == vec(Vec.(points(a), points(a)'))
-        @test  @inferred(checkpoints(a^2)) == vec(Vec.(checkpoints(a)', checkpoints(a)))
+        @test @inferred(points(a^2)) == vec(SVector.(points(a), points(a)'))
+        @test  @inferred(checkpoints(a^2)) == vec(SVector.(checkpoints(a)', checkpoints(a)))
 
         aa2 = @inferred TensorSpace(a , a^2)
         @test dimension(aa2) == dimension(a)^3
         @test @inferred(domain(aa2)) == domain(a)^3
-        @test @inferred(points(aa2)) == vec(Vec.(points(a), points(a)', reshape(points(a), 1,1,4)))
-        @test  @inferred(checkpoints(aa2)) == vec(Vec.(reshape(checkpoints(a), 1,1,length(checkpoints(a))), checkpoints(a)', checkpoints(a)))
+        @test @inferred(points(aa2)) == vec(SVector.(points(a), points(a)', reshape(points(a), 1,1,4)))
+        @test  @inferred(checkpoints(aa2)) == vec(SVector.(reshape(checkpoints(a), 1,1,length(checkpoints(a))), checkpoints(a)', checkpoints(a)))
 
         @test dimension(a^3) == dimension(a)^3
         @test @inferred(domain(a^3)) == domain(a)^3
-        @test_broken @inferred(points(a^3)) == vec(Vec.(points(a), points(a)', reshape(points(a), 1,1,4)))
+        @test_broken @inferred(points(a^3)) == vec(SVector.(points(a), points(a)', reshape(points(a), 1,1,4)))
 
         p = PointSpace(1:4)
         d = domain(p)


### PR DESCRIPTION
While the alias `Vec` is convenient, it's easy to confuse `Vec` with `Vector`. Explicitly spelling out `SVector` avoids this.