### PR TITLE
Support SVector in PiecewiseSegment

### DIFF
--- a/src/Domains/multivariate.jl
+++ b/src/Domains/multivariate.jl
@@ -6,11 +6,11 @@ include("ProductDomain.jl")
 const RectDomain = Union{DomainSets.FixedIntervalProduct{2}, DomainSets.Rectangle, VcatDomain{2,<:Any,(1,1),<:Tuple}}
 
 boundary(d::RectDomain) =
-    PiecewiseSegment([SVector(leftendpoint(factor(d,1)),leftendpoint(factor(d,2))),
+    PiecewiseSegment(SVector{5}(SVector(leftendpoint(factor(d,1)),leftendpoint(factor(d,2))),
                       SVector(rightendpoint(factor(d,1)),leftendpoint(factor(d,2))),
                       SVector(rightendpoint(factor(d,1)),rightendpoint(factor(d,2))),
                       SVector(leftendpoint(factor(d,1)),rightendpoint(factor(d,2))),
-                      SVector(leftendpoint(factor(d,1)),leftendpoint(factor(d,2)))])
+                      SVector(leftendpoint(factor(d,1)),leftendpoint(factor(d,2)))))
 
 
 ## Union


### PR DESCRIPTION
After this,
```julia
julia> dx = dy = ChebyshevInterval()
-1.0..1.0 (Chebyshev)

julia> using LinearAlgebra

julia> d = dx × dy
(-1.0..1.0 (Chebyshev)) × (-1.0..1.0 (Chebyshev))

julia> ∂(d)
PiecewiseSegment{StaticArraysCore.SVector{2, Float64}, StaticArraysCore.SVector{5, StaticArraysCore.SVector{2, Float64}}}(StaticArraysCore.SVector{2, Float64}[[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0], [-1.0, -1.0]])
```