### PR TITLE
Improve inference in PlusOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.35"
+version = "0.7.36"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,7 +213,7 @@ end
             f = Fun(PointSpace(1:3), c)
             M = Multiplication(f)
             @testset for t in [1, 3]
-                op = M + t * M
+                op = @inferred M + t * M
                 @test bandwidths(op) == bandwidths(M)
                 @test coefficients(op * f) == @. (1+t)*c^2
                 for op2 in Any[M + M + t * M, op + M]
@@ -230,9 +230,11 @@ end
                 @test coefficients(f1) == coefficients(f2) == coefficients(f3)
             end
             Z = ApproxFunBase.ZeroOperator()
-            @test Z + Z == Z
-            @test Z + Z + Z == Z
-            @test Z + Z + Z + Z == Z
+            @test (@inferred Z + Z) == Z
+            @test (@inferred Z + Z + Z) == Z
+            @test (@inferred Z + Z + Z + Z) == Z
+
+            @inferred (() -> (D = Derivative(); D + D))()
         end
     end
 


### PR DESCRIPTION
This uses a Tuple of operators internally instead of a Vector, which helps improve type inference.
```julia
julia> D = Derivative(Chebyshev(0..1));

julia> @btime $D + $D;
  5.558 μs (45 allocations: 2.09 KiB) # master
  2.119 μs (19 allocations: 1008 bytes) # PR

julia> M = Multiplication(Fun(Chebyshev(0..1)), Chebyshev(0..1));

julia> @btime $D + $M;
  8.598 μs (73 allocations: 3.38 KiB) # master
  3.840 μs (37 allocations: 1.88 KiB) # PR
```
After this PR, the following is fully inferred:
```julia
julia> @inferred (() -> (D = Derivative(Chebyshev(0..1)); D + D))()
PlusOperator : Chebyshev(0..1) → Ultraspherical(1,0..1)
 ⋅  4.0   ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅   8.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅   12.0    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅   16.0    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅   20.0    ⋅     ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅   24.0    ⋅     ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅   28.0    ⋅     ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   32.0    ⋅   ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   36.0  ⋅
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
 ⋅   ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
```