### PR TITLE
Pass eltype to PlusOperator

### DIFF
--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -25,6 +25,12 @@ function PlusOperator(opsin::Vector{O},
         ) where {O<:Operator}
     PlusOperator{eltype(O),typeof(bi),typeof(sz),O}(opsin,bi,sz)
 end
+function PlusOperator{ET}(opsin::Vector{O},
+        bi::Tuple{Any,Any} = bandwidthsmax(opsin),
+        sz::Tuple{Any,Any} = size(first(opsin)),
+        ) where {ET,O<:Operator{ET}}
+    PlusOperator{ET,typeof(bi),typeof(sz),O}(opsin,bi,sz)
+end
 
 bandwidths(P::PlusOperator) = P.bandwidths
 
@@ -54,8 +60,9 @@ end
 
 function promoteplus(opsin, sz = size(first(opsin)))
     ops = filter(!iszeroop, opsin)
+    ET = _promote_eltypeof(opsin)
     v = promotespaces(ops)
-    PlusOperator(convert_vector(v), bandwidthsmax(v), sz)
+    PlusOperator{ET}(convert_vector(v), bandwidthsmax(v), sz)
 end
 
 for OP in (:domainspace,:rangespace)


### PR DESCRIPTION
On master
```julia
julia> D = Derivative(Chebyshev(0..1));

julia> @code_warntype (D -> eltype(D + D))(D)
MethodInstance for (::var"#333#334")(::ApproxFunBase.ConcreteDerivative{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Int64, Float64})
  from (::var"#333#334")(D) in Main at REPL[24]:1
Arguments
  #self#::Core.Const(var"#333#334"())
  D::ApproxFunBase.ConcreteDerivative{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Int64, Float64}
Body::Any
1 ─ %1 = (D + D)::PlusOperator{_A, _B, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, _C} where {_A, _B, _C<:Operator{_A}}
│   %2 = Main.eltype(%1)::Any
└──      return %2
```
This PR
```julia
julia> @code_warntype (D -> eltype(D + D))(D)
MethodInstance for (::var"#335#336")(::ApproxFunBase.ConcreteDerivative{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Int64, Float64})
  from (::var"#335#336")(D) in Main at REPL[26]:1
Arguments
  #self#::Core.Const(var"#335#336"())
  D::ApproxFunBase.ConcreteDerivative{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Int64, Float64}
Body::Type{Float64}
1 ─ %1 = (D + D)::PlusOperator{Float64, _A, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, _B} where {_A, _B<:Operator{Float64}}
│   %2 = Main.eltype(%1)::Core.Const(Float64)
└──      return %2
```