### PR TITLE
Aggressive constprop in Fun * Operator

### DIFF
--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -573,13 +573,20 @@ end
 -(A::Operator) = ConstantTimesOperator(-1,A)
 -(A::Operator,B::Operator) = A+(-B)
 
-
-function *(f::Fun, A::Operator)
+@inline function _mulop(f::Fun, A::Operator)
     if isafunctional(A) && (isinf(bandwidth(A,1)) || isinf(bandwidth(A,2)))
         LowRankOperator(f,A)
     else
         TimesOperator(Multiplication(f,rangespace(A)),A)
     end
+end
+
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive function *(f::Fun, A::Operator)
+        _mulop(f, A)
+    end
+else
+    *(f::Fun, A::Operator) = _mulop(f, A)
 end
 
 *(c::Number,A::Operator) = ConstantTimesOperator(c,A)


### PR DESCRIPTION
This makes the following fully inferrable, with a corresponding change in `ApproxFunOrthogonalPolynomials`:
```julia
julia> @inferred (() -> Fun() * Derivative(Chebyshev()))()
TimesOperator : Chebyshev() → Ultraspherical(1)
 0.0  0.0  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   0.5  0.0  1.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   1.0  0.0  2.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   1.5  0.0  2.5   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   2.0  0.0  3.0   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   2.5  0.0  3.5   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   3.0  0.0  4.0   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   3.5  0.0  4.5  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   4.0  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   4.5  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
```