### PR TITLE
Trim trailing zeros in ProductFun(::Fun)

### DIFF
--- a/src/Multivariate/ProductFun.jl
+++ b/src/Multivariate/ProductFun.jl
@@ -172,7 +172,7 @@ function ProductFun(f::Fun{<:AbstractProductSpace}; kw...)
     M = coefficientmatrix(f)
     nc = ntrailingzerocols(M)
     nr = ntrailingzerorows(M)
-    A = @view M[1:end-nr, 1:end-nc]
+    A = @view M[1:max(1,end-nr), 1:max(1,end-nc)]
     ProductFun(A, space(f); kw...)
 end
 


### PR DESCRIPTION
After this
```julia
julia> F = Fun((x,y) ->x^2, Chebyshev()^2)
Fun(Chebyshev() ⊗ Chebyshev(), [0.5, 0.0, 0.0, 0.0, 0.0, 0.5])

julia> ProductFun(F) |> coefficients
3×1 Matrix{Float64}:
 0.5
 0.0
 0.5
```
Trailing zero columns along the second dimension are trimmed.