### PR TITLE
Retain `Vector{Operator{T}}` in `convert`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.40"
+version = "0.7.41"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -236,6 +236,21 @@ end
             @test (@inferred Z + Z + Z + Z) == Z
 
             @inferred (() -> (D = Derivative(); D + D))()
+
+            A = @inferred M + M
+            @test A * f ≈ 2 * (M * f)
+            M = Multiplication(f, space(f))
+            A = M + M
+            @test A * f ≈ 2 * (M * f)
+            B = @inferred convert(Operator{ComplexF64}, A)
+            @test eltype(B) == ComplexF64
+            @test B * f ≈ 2 * (M * f)
+
+            C = @inferred 2M
+            D = M + C
+            E = @inferred convert(Operator{ComplexF64}, D)
+            @test eltype(E) == ComplexF64
+            @test E * f ≈ 3 * (M * f)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,7 +235,7 @@ end
             @test (@inferred Z + Z + Z) == Z
             @test (@inferred Z + Z + Z + Z) == Z
 
-            @inferred (() -> (D = Derivative(); D + D))()
+            @inferred (() -> (local D = Derivative(); D + D))()
 
             A = @inferred M + M
             @test A * f ≈ 2 * (M * f)


### PR DESCRIPTION
In this PR, we assume that a `PlusOperator` or a `TimesOperator` wraps a `Vector{Operator{T}}` only if the components are incompatible, so the result of the `convert` may recreate the container for type-stability.