### PR TITLE
Optimized `TimesOperator` `AbstractRange` indexing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,6 +286,15 @@ end
             C = B * B
             @test_throws BoundsError @view C[1:2, 0:2]
             @test_throws BoundsError @view C[1:10, 1:2]
+
+            f = Fun(PointSpace(1:10))
+            M = Multiplication(f, space(f))
+            T = TimesOperator([M,M])
+            S = view(T, 1:2:7, 1:2:7)
+            B = BandedMatrix(S)
+            for I in CartesianIndices(B)
+                @test B[I] ≈ S[Tuple(I)...]
+            end
         end
     end
     @testset "conversion to a matrix" begin


### PR DESCRIPTION
This PR uses the fact that indexing a `TimesOperator` using `UnitRange`s is fast, so when indexing using `AbstractRange`s, we may instead index using `UnitRange`s, and index into the result with the original indices provided.
On master
```julia
julia> M = Multiplication(Fun(x -> x^10, Chebyshev()), Chebyshev());

julia> T = M * M;

julia> @btime $T[1:2:20, 1:2:20];
  269.429 μs (1003 allocations: 306.94 KiB)
```
This PR
```julia
julia> @btime $T[1:2:20, 1:2:20];
  28.857 μs (13 allocations: 22.33 KiB)
```