### PR TITLE
Speed up BlockInterlacer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.41"
+version = "0.7.42"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/ArraySpace.jl
+++ b/src/Spaces/ArraySpace.jl
@@ -32,7 +32,7 @@ Vector(sp::VectorSpace) = convert(Vector, sp.spaces)
 Matrix(sp::MatrixSpace) = convert(Matrix, sp.spaces)
 
 
-BlockInterlacer(sp::ArraySpace) = BlockInterlacer(blocklengths.(tuple(sp.spaces...)))
+BlockInterlacer(sp::ArraySpace) = BlockInterlacer(map(blocklengths, Tuple(sp.spaces)))
 interlacer(sp::ArraySpace) = BlockInterlacer(sp)
 
 for OP in (:length,:firstindex,:lastindex,:size)


### PR DESCRIPTION
On master
```julia
julia> sp = ApproxFunBase.ArraySpace(fill(Chebyshev(),2))
2-element ArraySpace:
[Chebyshev(), Chebyshev()]

julia> @btime ApproxFunBase.interlacer($sp);
  405.720 ns (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime ApproxFunBase.interlacer($sp);
  230.925 ns (0 allocations: 0 bytes)
```