### PR TITLE
Union of types in interlaceoperator

### DIFF
--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -179,6 +179,10 @@ InterlaceOperator(opsin::AbstractMatrix,S...) =
     InterlaceOperator(Matrix{Operator{promote_eltypeof(opsin)}}(promotespaces(opsin)),S...)
 
 _convert_vector_or_svector(v::AbstractVector) = convert_vector(v)
+_uniontypes_svector(t) = SVector{length(t), mapfoldl(typeof, (x,y)->Union{x,y}, t)}(t)
+_convert_vector_or_svector(t::NTuple{2,Any}) = _uniontypes_svector(t)
+_convert_vector_or_svector(t::NTuple{3,Any}) = _uniontypes_svector(t)
+_convert_vector_or_svector(t::NTuple{4,Any}) = _uniontypes_svector(t)
 _convert_vector_or_svector(t::Tuple) = SVector{length(t), mapreduce(typeof, typejoin, t)}(t)
 
 function InterlaceOperator(opsin::AbstractVector{<:Operator})


### PR DESCRIPTION
This provides a marginal performance improvement
On master
```julia
julia> O = @btime [$(Dirichlet(Chebyshev())); $(Derivative(Chebyshev()))];
  6.764 μs (63 allocations: 2.72 KiB)

julia> rangespace(O)
2-element ArraySpace:
Space[2-element ArraySpace:
ConstantSpace{DomainSets.Point{Float64}, Float64}[ConstantSpace(Point(-1.0)), ConstantSpace(Point(1.0))], Ultraspherical(1)]
```
This PR
```julia
julia> O = @btime [$(Dirichlet(Chebyshev())); $(Derivative(Chebyshev()))];
  4.980 μs (48 allocations: 2.39 KiB)

julia> rangespace(O)
2-element ArraySpace:
Union{ApproxFunBase.ArraySpace{ConstantSpace{DomainSets.Point{Float64}, Float64}, 1, DomainSets.Point{Float64}, Float64, StaticArraysCore.SVector{2, ConstantSpace{DomainSets.Point{Float64}, Float64}}}, Ultraspherical{Int64, ChebyshevInterval{Float64}, Float64}}[2-element ArraySpace:
ConstantSpace{DomainSets.Point{Float64}, Float64}[ConstantSpace(Point(-1.0)), ConstantSpace(Point(1.0))], Ultraspherical(1)]
```