### PR TITLE
Numbers as derivative orders

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.42"
+version = "0.7.43"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -112,12 +112,21 @@ uniontypedvec(A, B) = Union{typeof(A), typeof(B)}[A, B]
 convert_vector(v::AbstractVector) = convert(Vector, v)
 convert_vector(t::Tuple) = [t...]
 
+convert_vector_or_svector(v::AbstractVector) = convert(Vector, v)
+convert_vector_or_svector(t::Tuple) = SVector(t)
+
 promote_eltypeof(As...) = promote_eltypeof(As)
 # Avoid mapreduce for common cases, as it often suffers from poor type inference
 promote_eltypeof(As::Tuple{Any}) = eltype(As[1])
 promote_eltypeof(As::Tuple{Any,Any}) = promote_type(eltype(As[1]), eltype(As[2]))
 promote_eltypeof(As::Tuple{Any,Any,Any}) = promote_type(eltype(As[1]), eltype(As[2]), eltype(As[3]))
 promote_eltypeof(As::Union{AbstractArray, Tuple}) = mapfoldl(eltype, promote_type, As)
+
+assert_integer(::Integer) = nothing
+function assert_integer(k::Number)
+    @assert Integer(k) == k "order must be an integer"
+    return nothing
+end
 
 include("LinearAlgebra/LinearAlgebra.jl")
 include("Fun.jl")

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -31,6 +31,7 @@ macro calculus_operator(Op)
 
         $Op(sp::ApproxFunBase.UnsetSpace,k) = $ConcOp(sp,k)
         $Op(sp::ApproxFunBase.UnsetSpace,k::Number) = $ConcOp(sp,k)
+        $Op(sp::ApproxFunBase.UnsetSpace,k::Real) = $ConcOp(sp,k)
         $Op(sp::ApproxFunBase.UnsetSpace,k::Integer) = $ConcOp(sp,k)
 
         function $DefaultOp(sp::Space,k)

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -30,7 +30,7 @@ macro calculus_operator(Op)
         $ConcOp(sp::Space,k) = $ConcOp{typeof(sp),typeof(k),ApproxFunBase.prectype(sp)}(sp,k)
 
         $Op(sp::ApproxFunBase.UnsetSpace,k) = $ConcOp(sp,k)
-        $Op(sp::ApproxFunBase.UnsetSpace,k::Real) = $ConcOp(sp,k)
+        $Op(sp::ApproxFunBase.UnsetSpace,k::Number) = $ConcOp(sp,k)
         $Op(sp::ApproxFunBase.UnsetSpace,k::Integer) = $ConcOp(sp,k)
 
         function $DefaultOp(sp::Space,k)
@@ -183,7 +183,8 @@ end
 
 
 ## Map to canonical
-function DefaultDerivative(sp::Space,k::Integer)
+function DefaultDerivative(sp::Space, k::Number)
+    assert_integer(k)
     if typeof(canonicaldomain(sp)).name==typeof(domain(sp)).name
         # this is the normal default constructor
         csp=canonicalspace(sp)
@@ -212,7 +213,8 @@ function DefaultDerivative(sp::Space,k::Integer)
 end
 
 
-function DefaultIntegral(sp::Space,k::Integer)
+function DefaultIntegral(sp::Space, k::Number)
+    assert_integer(k)
     if typeof(canonicaldomain(sp)).name==typeof(domain(sp)).name
         # this is the normal default constructor
         csp=canonicalspace(sp)

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -47,7 +47,7 @@ function rangespace(A::VectorOrTupleOfOp)
         error("Cannot construct rangespace for $A as domain spaces are not compatible")
     end
     spl=map(rangespace, A)
-    ArraySpace(_convert_vector_or_svector(spl), first(spl))
+    ArraySpace(_convert_vector_promotetypes(spl), first(spl))
 end
 
 promotespaces(A::AbstractMatrix{<:Operator}) = promotespaces(Matrix(A))
@@ -178,12 +178,12 @@ InterlaceOperator(opsin::AbstractMatrix{<:Operator},::Type{DS}) where {DS<:Space
 InterlaceOperator(opsin::AbstractMatrix,S...) =
     InterlaceOperator(Matrix{Operator{promote_eltypeof(opsin)}}(promotespaces(opsin)),S...)
 
-_convert_vector_or_svector(v::AbstractVector) = convert_vector(v)
+_convert_vector_promotetypes(v::AbstractVector) = convert_vector(v)
 _uniontypes_svector(t) = SVector{length(t), mapfoldl(typeof, (x,y)->Union{x,y}, t)}(t)
-_convert_vector_or_svector(t::NTuple{2,Any}) = _uniontypes_svector(t)
-_convert_vector_or_svector(t::NTuple{3,Any}) = _uniontypes_svector(t)
-_convert_vector_or_svector(t::NTuple{4,Any}) = _uniontypes_svector(t)
-_convert_vector_or_svector(t::Tuple) = SVector{length(t), mapreduce(typeof, typejoin, t)}(t)
+_convert_vector_promotetypes(t::NTuple{2,Any}) = _uniontypes_svector(t)
+_convert_vector_promotetypes(t::NTuple{3,Any}) = _uniontypes_svector(t)
+_convert_vector_promotetypes(t::NTuple{4,Any}) = _uniontypes_svector(t)
+_convert_vector_promotetypes(t::Tuple) = SVector{length(t), mapreduce(typeof, typejoin, t)}(t)
 
 function InterlaceOperator(opsin::AbstractVector{<:Operator})
     ops = convert_vector(promotedomainspace(opsin))


### PR DESCRIPTION
Passing `StaticInt`s as derivative orders helps with type inference. This PR also removes some splatting in constructing vectors.