### PR TITLE
domainscompatible for different closedness

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.45"
+version = "0.7.46"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
We may break early while comparing intervals in `domainscompatible` if the endpoints differ, even if the closedness is different.