### PR TITLE
Don't import deprecated `DomainSets` functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.46"
+version = "0.7.47"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -4,7 +4,6 @@ using Base, BlockArrays, BandedMatrices, BlockBandedMatrices, DomainSets,
               IntervalSets, SpecialFunctions, AbstractFFTs, FFTW,
               SpecialFunctions, DSP, DualNumbers, LinearAlgebra, SparseArrays,
               LowRankApprox, FillArrays, InfiniteArrays, InfiniteLinearAlgebra
-              # Arpack
 
 import StaticArrays, Calculus
 using StaticArrays: SVector, @SArray, SArray
@@ -12,7 +11,8 @@ using StaticArrays: SVector, @SArray, SArray
 import DomainSets: Domain, indomain, UnionDomain, ProductDomain, Point, ∂,
               elements, DifferenceDomain, Interval, ChebyshevInterval, boundary,
               rightendpoint, leftendpoint, dimension, WrappedDomain, VcatDomain,
-              component, components, ncomponents
+              component, components, ncomponents, factor, factors, nfactors,
+              canonicaldomain
 
 using AbstractFFTs: Plan
 

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -9,7 +9,7 @@ import StaticArrays, Calculus
 using StaticArrays: SVector, @SArray, SArray
 
 import DomainSets: Domain, indomain, UnionDomain, ProductDomain, Point, ∂,
-              elements, DifferenceDomain, Interval, ChebyshevInterval, boundary,
+              SetdiffDomain, Interval, ChebyshevInterval, boundary,
               rightendpoint, leftendpoint, dimension, WrappedDomain, VcatDomain,
               component, components, ncomponents, factor, factors, nfactors,
               canonicaldomain

--- a/src/Domains/Domains.jl
+++ b/src/Domains/Domains.jl
@@ -31,7 +31,7 @@ end
 function Base.setdiff(d::SegmentDomain,p::Point)
     x = Number(p)
     (x ∉ d || x ≈ leftendpoint(d) || x ≈ rightendpoint(d)) && return d
-    DifferenceDomain(d,p)
+    SetdiffDomain(d,p)
 end
 
 
@@ -41,7 +41,7 @@ end
 include("multivariate.jl")
 
 affine_setdiff(d::Domain, ptsin::UnionDomain) =
-    _affine_setdiff(d, Number.(elements(ptsin)))
+    _affine_setdiff(d, Number.(components(ptsin)))
 
 affine_setdiff(d::Domain, ptsin::WrappedDomain{<:AbstractVector}) =
     _affine_setdiff(d, ptsin.domain)

--- a/src/Domains/ProductDomain.jl
+++ b/src/Domains/ProductDomain.jl
@@ -1,11 +1,3 @@
-
-nfactors(d::ProductDomain) = length(components(d))
-factors(d::ProductDomain) = components(d)
-factor(d::ProductDomain,k::Integer) = component(d,k)
-
-canonicaldomain(d::ProductDomain) = ProductDomain(map(canonicaldomain,factors(d))...)
-
-
 # product domains are their own canonical domain
 for OP in (:fromcanonical,:tocanonical)
     @eval begin

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -303,6 +303,8 @@ TensorSpace(sp::Tuple) =
 
 dimension(sp::TensorSpace) = mapreduce(dimension,*,sp.spaces)
 
+==(A::TensorSpace{<:NTuple{2,Space}}, B::TensorSpace{<:NTuple{2,Space}}) =
+    factors(A) == factors(B)
 ==(A::TensorSpace{<:NTuple{N,Space}}, B::TensorSpace{<:NTuple{N,Space}}) where {N} =
         all(((a,b),) -> a == b, zip(factors(A), factors(B)))
 

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -303,10 +303,8 @@ TensorSpace(sp::Tuple) =
 
 dimension(sp::TensorSpace) = mapreduce(dimension,*,sp.spaces)
 
-==(A::TensorSpace{<:NTuple{2,Space}}, B::TensorSpace{<:NTuple{2,Space}}) =
-    factors(A) == factors(B)
 ==(A::TensorSpace{<:NTuple{N,Space}}, B::TensorSpace{<:NTuple{N,Space}}) where {N} =
-        all(((a,b),) -> a == b, zip(factors(A), factors(B)))
+        factors(A) == factors(B)
 
 conversion_rule(a::TensorSpace{<:NTuple{2,Space}}, b::TensorSpace{<:NTuple{2,Space}}) =
     conversion_type(a.spaces[1],b.spaces[1]) ⊗ conversion_type(a.spaces[2],b.spaces[2])

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -255,7 +255,7 @@ Base.transpose(S::ConstantTimesOperator) = sp.c*transpose(S.op)
 ### Calculus
 
 #TODO: general dimension
-function Derivative(S::TensorSpace{SV,DD}, order) where {SV,DD<:EuclideanDomain{2}}
+function Derivative(S::TensorSpace{<:Any,<:EuclideanDomain{2}}, order)
     @assert length(order)==2
     if order[1]==0
         Dy=Derivative(S.spaces[2],order[2])
@@ -272,7 +272,7 @@ function Derivative(S::TensorSpace{SV,DD}, order) where {SV,DD<:EuclideanDomain{
         T=promote_type(eltype(Dx),eltype(Dy))
     end
     # try to work around type inference
-    DerivativeWrapper{typeof(K),typeof(S),Vector{Int},T}(K,order)
+    DerivativeWrapper{typeof(K),typeof(S),typeof(order),T}(K,order)
 end
 
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -265,6 +265,8 @@ using LinearAlgebra
             @test ApproxFunBase.spacescompatible(a, a)
             b = PointSpace(1:4) ⊗ PointSpace(1:3)
             @test !ApproxFunBase.spacescompatible(a, b)
+            @test a == a
+            @test a != b
         end
     end
 


### PR DESCRIPTION
Also, don't overwrite `DomainSets` functions such as `factors`.