### PR TITLE
don't use A_mul_B in kron multiplication

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.48"
+version = "0.7.49"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/Conversion.jl
+++ b/src/Operators/banded/Conversion.jl
@@ -99,6 +99,7 @@ function convert(::Type{Operator{T}},D::ConversionWrapper) where T
     end
 end
 
+convert(::Type{T}, C::ConversionWrapper) where {T<:Number} = strictconvert(T, C.op)
 
 
 #promotedomainspace(P::Conversion,sp::Space)=ConversionWrapper(Operator(I, sp))

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -566,14 +566,10 @@ end
 
 # Conversions we always assume are intentional: no need to promote
 
-*(A::ConversionWrapper{TO1},B::ConversionWrapper{TO}) where {TO1<:TimesOperator,TO<:TimesOperator} =
-    ConversionWrapper(TimesOperator(A.op,B.op))
-*(A::ConversionWrapper{TO},B::Conversion) where {TO<:TimesOperator} =
-    ConversionWrapper(TimesOperator(A.op,B))
-*(A::Conversion,B::ConversionWrapper{TO}) where {TO<:TimesOperator} =
-    ConversionWrapper(TimesOperator(A,B.op))
+_unwrap_conversion(c) = c
+_unwrap_conversion(c::ConversionWrapper{<:TimesOperator}) = c.op
 
-*(A::Conversion,B::Conversion) = ConversionWrapper(TimesOperator(A,B))
+*(A::Conversion,B::Conversion) = ConversionWrapper(TimesOperator(_unwrap_conversion(A), _unwrap_conversion(B)))
 *(A::Conversion,B::TimesOperator) = TimesOperator(A,B)
 *(A::TimesOperator,B::Conversion) = TimesOperator(A,B)
 *(A::Operator,B::Conversion) =

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -213,8 +213,8 @@ function *(A::KroneckerOperator, B::KroneckerOperator)
     rspA = rangespace(A)
     A1, A2 = A.ops
     B1, B2 = B.ops
-    AB1 = A_mul_B(A1, B1; dspB = factor(dspB,1), rspA = factor(rspA,1))
-    AB2 = A_mul_B(A2, B2; dspB = factor(dspB,2), rspA = factor(rspA,2))
+    AB1 = A1 * B1
+    AB2 = A2 * B2
     KroneckerOperator(AB1, AB2, dspB, rspA)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,6 +326,10 @@ end
         B = ApproxFunBase.promotespaces((M, M))
         @test all(((x,y),) -> x == y, zip(A, B))
     end
+    @testset "conversion and constantoperator" begin
+        A = Conversion(PointSpace(1:4), PointSpace(1:4))
+        @test convert(Number, A) == 1
+    end
 end
 
 @testset "RowVector" begin


### PR DESCRIPTION
Bugfix, as `A_mul_B` isn't defined for all operators. This should only be used in specific cases.