### PR TITLE
type fix

### DIFF
--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -694,7 +694,7 @@ struct BlockInterlacer{DMS<:Tuple}
 end
 
 
-const TrivialInterlacer{d} = BlockInterlacer{NTuple{d,<:Ones}}
+const TrivialInterlacer{d} = BlockInterlacer{<:NTuple{d,Ones}}
 
 BlockInterlacer(v::AbstractVector) = BlockInterlacer(tuple(v...))
 


### PR DESCRIPTION
Small type fix which makes some simple sumspaces not be treated as such.
Significantly improves the performance for `Fourier` spaces.