### PR TITLE
Fix boxing in TrivialTensorizer next

### DIFF
--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -51,7 +51,7 @@ function next(a::TrivialTensorizer{d}, iterator_tuple) where {d}
     (block, (j, iterator, iter_state)), (i,tot) = iterator_tuple
 
 
-    @inline function check_block_finished()
+    @inline function check_block_finished(j, iterator, block)
         if iterator === nothing
             return true
         end
@@ -63,8 +63,7 @@ function next(a::TrivialTensorizer{d}, iterator_tuple) where {d}
 
     ret = reverse(block)
 
-    if check_block_finished()   # end of new block
-
+    if check_block_finished(j, iterator, block)   # end of new block
         # set up iterator for new block
         current_sum = sum(block)
         iterator = multiexponents(d, current_sum+1-d)


### PR DESCRIPTION
On master
```julia
julia> f3 = Fun(Chebyshev()^3, rand(100));

julia> @btime $f3(0.1, 0.1, 0.1);
  146.563 μs (1869 allocations: 98.86 KiB)
```
This PR
```julia
julia> @btime $f3(0.1, 0.1, 0.1);
  21.280 μs (563 allocations: 37.64 KiB)
```
cc @benjione 