### PR TITLE
Static vector in `Tensorizer` next

### DIFF
--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -38,7 +38,7 @@ function start(a::TrivialTensorizer{d}) where {d}
         return invoke(start, Tuple{Tensorizer2D}, a)
     else
         # ((block_dim_1, block_dim_2,...), (itaration_number, iterator, iterator_state)), (itemssofar, length)
-        return (ones(Int, d),(0, nothing, nothing)), (0,length(a))
+        return (SizedVector{d}(ones(Int, d)),(0, nothing, nothing)), (0,length(a))
     end
 end
 

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -38,7 +38,8 @@ function start(a::TrivialTensorizer{d}) where {d}
         return invoke(start, Tuple{Tensorizer2D}, a)
     else
         # ((block_dim_1, block_dim_2,...), (itaration_number, iterator, iterator_state)), (itemssofar, length)
-        return (SizedVector{d}(ones(Int, d)),(0, nothing, nothing)), (0,length(a))
+        block = SVector{d}(Ones{Int}(d))
+        return (block, (0, nothing, nothing)), (0,length(a))
     end
 end
 
@@ -72,8 +73,9 @@ function next(a::TrivialTensorizer{d}, iterator_tuple) where {d}
     end
 
     # increase block, or initialize new block
-    res, iter_state = iterate(iterator, iter_state)
-    block .= res.+1
+    _res, iter_state = iterate(iterator, iter_state)
+    res = SVector{d}(_res)
+    block = res.+1
     j = j+1
 
     ret, ((block, (j, iterator, iter_state)), (i,tot))


### PR DESCRIPTION
This provides a performance boost
On master
```julia
julia> f3 = Fun(Chebyshev()^3, rand(1000));

julia> @btime $f3(0.1, 0.1, 0.1);
  219.015 μs (5133 allocations: 390.56 KiB)
```
This PR
```julia
julia> @btime $f3(0.1, 0.1, 0.1);
  175.871 μs (4132 allocations: 312.36 KiB)
```
Currently, iterating over `MultiExponents` is expensive, as it allocates an array in each iteration. Since the size of the array is constant, the allocation may be moved to the constructor. 