### PR TITLE
Move `Fun(::Interval)` constructor from AFOP

### DIFF
--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -248,6 +248,13 @@ for TYP in (:Derivative,:Integral,:Laplacian)
     end
 end
 
+# the default domain space is higher to avoid negative ultraspherical spaces
+function Integral(d::IntervalOrSegment,n::Integer)
+    ds = Space(d)
+    rs = rangespace(Derivative(ds))
+    Integral(rs, n)
+end
+
 ==(A::Derivative, B::Derivative) = A.order == B.order && domainspace(A) == domainspace(B)
 
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -183,6 +183,9 @@ function Fun(::typeof(identity), d::Domain)
     end
 end
 
+Fun(::typeof(identity), d::IntervalOrSegment{<:Number}) =
+    Fun(Space(d), [mean(d), complexlength(d)/2])
+
 Fun(::typeof(identity), S::Space) = Fun(identity,domain(S))
 
 


### PR DESCRIPTION
This reduces type-piracy in that package