### PR TITLE
revert moving integral

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.50"
+version = "0.7.51"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -248,13 +248,6 @@ for TYP in (:Derivative,:Integral,:Laplacian)
     end
 end
 
-# the default domain space is higher to avoid negative ultraspherical spaces
-function Integral(d::IntervalOrSegment,n::Integer)
-    ds = Space(d)
-    rs = rangespace(Derivative(ds))
-    Integral(rs, n)
-end
-
 ==(A::Derivative, B::Derivative) = A.order == B.order && domainspace(A) == domainspace(B)
 
 


### PR DESCRIPTION
This creates type-inference issues, so reverting the change.