### PR TITLE
Compare matrices in backend_testinfoperator

### DIFF
--- a/ApproxFunBaseTest/Project.toml
+++ b/ApproxFunBaseTest/Project.toml
@@ -1,7 +1,7 @@
 name = "ApproxFunBaseTest"
 uuid = "a931bfaf-0cfd-4a5c-b69c-bf2eed002b43"
 authors = ["Jishnu Bhattacharya <jishnub.github@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"


### PR DESCRIPTION
Compare matrices instead of `BandedMatrix` instances, which is often faster from a TTFX viewpoint