### PR TITLE
Distinguish between BLAS and LinearAlgebra axpy

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        julia-version: [1, 1.6]
+        julia-version: ['1', '1.6', '~1.9.0-0']
         os: [ubuntu-latest]
         package:
           - {repo: ApproxFun.jl, group: JuliaApproximation}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.52"
+version = "0.7.53"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/LinearAlgebra/RaggedMatrix.jl
+++ b/src/LinearAlgebra/RaggedMatrix.jl
@@ -226,7 +226,8 @@ function unsafe_mul!(Y::RaggedMatrix,A::RaggedMatrix,B::RaggedMatrix)
     fill!(Y.data,0)
 
     for j=1:size(B,2),k=1:colstop(B,j)
-        BLAS.axpy!(B[k,j],view(A,1:colstop(A,k),k),view(Y.data,Y.cols[j] .- 1 .+ (1:colstop(A,k))))
+        LinearAlgebra.axpy!(B[k,j], view(A,1:colstop(A,k),k),
+            view(Y.data,Y.cols[j] .- 1 .+ (1:colstop(A,k))))
     end
 
     Y

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -349,7 +349,7 @@ for TYP in (:BandedMatrix, :BlockBandedMatrix, :BandedBlockBandedMatrix, :Ragged
                 if !isempty(ret_kr)
                     sub_kr=cr[ret_kr[1]][2]:cr[ret_kr[end]][2]
 
-                    LinearAlgebra.axpy!(1.0,view(L.ops[ν],sub_kr,jr),view(ret,ret_kr,:))
+                    BLAS.axpy!(1.0,view(L.ops[ν],sub_kr,jr),view(ret,ret_kr,:))
                 end
             end
             ret
@@ -380,7 +380,7 @@ for TYP in (:BandedMatrix, :BlockBandedMatrix, :BandedBlockBandedMatrix, :Ragged
                     sub_kr=cr[ret_kr[1]][2]:cr[ret_kr[end]][2]
                     sub_jr=cd[ret_jr[1]][2]:cd[ret_jr[end]][2]
 
-                    LinearAlgebra.axpy!(1.0,view(L.ops[ν,μ],sub_kr,sub_jr),
+                    BLAS.axpy!(1.0,view(L.ops[ν,μ],sub_kr,sub_jr),
                                    view(ret,ret_kr,ret_jr))
                 end
             end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -95,8 +95,13 @@ Fun(c::Number,d::Domain) = c==0 ? c*zeros(d) : c*ones(d)
 Fun(c::Number,d::Space) = c==0 ? c*zeros(prectype(d),d) : c*ones(prectype(d),d)
 
 ## Adaptive constructors
+if VERSION >= v"1.9.0-"
+    _splat(f) = Base.Splat(f)
+else
+    _splat(f) = Base.splat(f)
+end
 function default_Fun(f, d::Space)
-    _default_Fun(hasnumargs(f, 1) ? f : Base.splat(f), d)
+    _default_Fun(hasnumargs(f, 1) ? f : _splat(f), d)
 end
 # In _default_Fun, we know that the function takes a single argument
 function _default_Fun(f, d::Space)


### PR DESCRIPTION
On Julia v1.9, `LinearAlgebra.axpy! !== BLAS.axpy!`, which made some tests fail.

Perhaps we should only extend `LinearAlgebra.axpy!` in this package. However, for now, just fixing the breakages is less disruptive for now.