### PR TITLE
revert optimization level in downstream

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -48,7 +48,7 @@ jobs:
           repository: ${{ matrix.package.group }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream -O0 {0}
+        shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
           try


### PR DESCRIPTION
Julia v1.6 seems to be buggy, as some tests for `ApproxFunOrthogonalPolynomials` fail with O0 and O1 but work with O2 (floating-point precision changes with optimization level). This doesn't happen for other versions (1.8 and above). I'm reverting the optimization level to the default (O2) for now, but in the future, perhaps we can have a more granular optimization setting.