### PR TITLE
Constprop in defaultderiv

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.55"
+version = "0.7.56"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -184,7 +184,7 @@ end
 
 
 ## Map to canonical
-function DefaultDerivative(sp::Space, k::Number)
+@inline function _DefaultDerivative(sp::Space, k::Number)
     assert_integer(k)
     if typeof(canonicaldomain(sp)).name==typeof(domain(sp)).name
         # this is the normal default constructor
@@ -213,6 +213,12 @@ function DefaultDerivative(sp::Space, k::Number)
     end
 end
 
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive DefaultDerivative(sp::Space, k::Number) =
+        _DefaultDerivative(sp, k)
+else
+    DefaultDerivative(sp::Space, k::Number) = _DefaultDerivative(sp, k)
+end
 
 function DefaultIntegral(sp::Space, k::Number)
     assert_integer(k)


### PR DESCRIPTION
After this, the following is type-stable:
```julia
julia> @inferred Derivative(NormalizedChebyshev(0..1))
DerivativeWrapper : NormalizedChebyshev(0..1) → Ultraspherical(1,0..1)
 ⋅  2.25676   ⋅        ⋅        ⋅         ⋅        ⋅        ⋅        ⋅        ⋅      ⋅
 ⋅   ⋅       4.51352   ⋅        ⋅         ⋅        ⋅        ⋅        ⋅        ⋅      ⋅
 ⋅   ⋅        ⋅       6.77028   ⋅         ⋅        ⋅        ⋅        ⋅        ⋅      ⋅
 ⋅   ⋅        ⋅        ⋅       9.02703    ⋅        ⋅        ⋅        ⋅        ⋅      ⋅
 ⋅   ⋅        ⋅        ⋅        ⋅       11.2838    ⋅        ⋅        ⋅        ⋅      ⋅
 ⋅   ⋅        ⋅        ⋅        ⋅         ⋅      13.5406    ⋅        ⋅        ⋅      ⋅
 ⋅   ⋅        ⋅        ⋅        ⋅         ⋅        ⋅      15.7973    ⋅        ⋅      ⋅
 ⋅   ⋅        ⋅        ⋅        ⋅         ⋅        ⋅        ⋅      18.0541    ⋅      ⋅
 ⋅   ⋅        ⋅        ⋅        ⋅         ⋅        ⋅        ⋅        ⋅      20.3108  ⋅
 ⋅   ⋅        ⋅        ⋅        ⋅         ⋅        ⋅        ⋅        ⋅        ⋅      ⋱
 ⋅   ⋅        ⋅        ⋅        ⋅         ⋅        ⋅        ⋅        ⋅        ⋅      ⋱
```