### PR TITLE
Shorter isapproxinteger check for integers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.57"
+version = "0.7.58"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -51,7 +51,7 @@ end
 
 # The second case handles zero
 isapproxinteger(::Integer) = true
-isapproxinteger(x) = isapprox(x,round(Int,x))  || isapprox(x+1,round(Int,x+1))
+isapproxinteger(x) = isinteger(x) || isapprox(x,round(Int,x))  || isapprox(x+1,round(Int,x+1))
 
 
 # This creates ApproxFunBase.real, ApproxFunBase.eps and ApproxFunBase.dou


### PR DESCRIPTION
Check for `isinteger` first in `isapproxinteger`, which would deal with static integers.