### PR TITLE
Specialize `isdiag` for `KroneckerOperator`

### DIFF
--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -549,6 +549,8 @@ macro wrappergetindex(Wrap)
             ApproxFunBase.mul_coefficients(view(parent(A).op,S.indexes[1],S.indexes[2]),b)
         ApproxFunBase.mul_coefficients(A::ApproxFunBase.SubOperator{T,OP},b) where {T,OP<:$Wrap} =
             ApproxFunBase.mul_coefficients(view(parent(A).op,S.indexes[1],S.indexes[2]),b)
+
+        isdiag(W::$Wrap) = isdiag(W.op)
     end
 
     for TYP in (:(ApproxFunBase.BandedMatrix),:(ApproxFunBase.RaggedMatrix),

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -105,7 +105,7 @@ end
 
 bandwidths(K::KroneckerOperator) = (ℵ₀,ℵ₀)
 
-for f in [:isblockbanded, :israggedbelow]
+for f in [:isblockbanded, :israggedbelow, :isdiag]
     _f = Symbol(:_, f)
     @eval begin
         $f(K::KroneckerOperator) = $(_f)(K.ops)


### PR DESCRIPTION
After this,
```julia
julia> C = Conversion(Chebyshev()*Legendre(), Chebyshev()*Legendre())
ConversionWrapper : Chebyshev() ⊗ Legendre() → Chebyshev() ⊗ Legendre()
 1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋯
 0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋱
 0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋱
 0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋱
 0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0  ⋱
 0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0  ⋱
 0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0  ⋱
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0  ⋱
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0  ⋱
 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  ⋱
  ⋮    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱   ⋱

julia> using LinearAlgebra

julia> isdiag(C)
true
```
On master
```julia
julia> isdiag(C)
false
```