### PR TITLE
Diagonal `KroneckerOperator` has zero bandwidth

### DIFF
--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -103,7 +103,7 @@ function rowstop(A::KroneckerOperator,k::Integer)
 end
 
 
-bandwidths(K::KroneckerOperator) = (ℵ₀,ℵ₀)
+bandwidths(K::KroneckerOperator) = isdiag(K) ? (0,0) : (ℵ₀,ℵ₀)
 
 for f in [:isblockbanded, :israggedbelow, :isdiag]
     _f = Symbol(:_, f)


### PR DESCRIPTION
This means that diagonal conversions won't become `RaggedMatrix`es:
```julia
julia> C = Conversion(Chebyshev()*Legendre(), Chebyshev()*NormalizedLegendre())
ConversionWrapper : Chebyshev() ⊗ Legendre() → Chebyshev() ⊗ NormalizedLegendre()
 1.41421   ⋅         ⋅        ⋅         ⋅         ⋅        ⋅         ⋅         ⋅         ⋅       ⋅
  ⋅       0.816497   ⋅        ⋅         ⋅         ⋅        ⋅         ⋅         ⋅         ⋅       ⋅
  ⋅        ⋅        1.41421   ⋅         ⋅         ⋅        ⋅         ⋅         ⋅         ⋅       ⋅
  ⋅        ⋅         ⋅       0.632456   ⋅         ⋅        ⋅         ⋅         ⋅         ⋅       ⋅
  ⋅        ⋅         ⋅        ⋅        0.816497   ⋅        ⋅         ⋅         ⋅         ⋅       ⋅
  ⋅        ⋅         ⋅        ⋅         ⋅        1.41421   ⋅         ⋅         ⋅         ⋅       ⋅
  ⋅        ⋅         ⋅        ⋅         ⋅         ⋅       0.534522   ⋅         ⋅         ⋅       ⋅
  ⋅        ⋅         ⋅        ⋅         ⋅         ⋅        ⋅        0.632456   ⋅         ⋅       ⋅
  ⋅        ⋅         ⋅        ⋅         ⋅         ⋅        ⋅         ⋅        0.816497   ⋅       ⋅
  ⋅        ⋅         ⋅        ⋅         ⋅         ⋅        ⋅         ⋅         ⋅        1.41421  ⋅
  ⋅        ⋅         ⋅        ⋅         ⋅         ⋅        ⋅         ⋅         ⋅         ⋅       ⋱

julia> C[1:4, 1:4]
4×4 BandedMatrix{Float64} with bandwidths (0, 0):
 1.41421   ⋅         ⋅        ⋅ 
  ⋅       0.816497   ⋅        ⋅ 
  ⋅        ⋅        1.41421   ⋅ 
  ⋅        ⋅         ⋅       0.632456
```