### PR TITLE
Improve inference in blockintercer iteration

### DIFF
--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -752,7 +752,7 @@ function iterate(it::BlockInterlacer, (N,k,blkst,lngs))
     end
 
 
-    lngs = tuple(lngs[1:N-1]...,lngs[N]+1,lngs[N+1:end]...)
+    lngs = tuple(lngs[1:N-1]...,lngs[N]+1,lngs[N+1:end]...)::typeof(lngs)
     return (N,lngs[N]),(N,k+1,blkst,lngs)
 end
 

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -752,7 +752,7 @@ function iterate(it::BlockInterlacer, (N,k,blkst,lngs))
     end
 
 
-    lngs = tuple(lngs[1:N-1]...,lngs[N]+1,lngs[N+1:end]...)::typeof(lngs)
+    lngs = Base.setindex(lngs, lngs[N]+1, N)
     return (N,lngs[N]),(N,k+1,blkst,lngs)
 end
 


### PR DESCRIPTION
On master
```julia
julia> s = Fourier();

julia> b = ApproxFunBase.BlockInterlacer(s);

julia> @btime first($b, 10);
  6.564 μs (124 allocations: 6.95 KiB)
```
This PR
```julia
julia> @btime first($b, 10);
  1.103 μs (28 allocations: 2.31 KiB)
```