### PR TITLE
Constant propagation in `Fun` multiplication

### DIFF
--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -599,13 +599,9 @@ end
     elseif k==1
         f
     elseif k==2
-        f * f
-    elseif k==3
-        f * f * f
-    elseif k==4
-        f * f * f * f
+        *(f, f, domcomp=true)
     else
-        t = foldl(*, fill(f, abs(k)-1), init=f)
+        t = foldl((x,y) -> *(x, y, domcomp=true), Fill(f, abs(k)-1), init=f)
         if k > 0
             return t
         else
@@ -615,17 +611,6 @@ end
 end
 
 ^(f::Fun, k::Integer) = intpow(f,k)
-# Ideally, constant propagation in intpow would handle literal exponentiation,
-# but currently inference doesn't succeed for f * f for arbitrary domains.
-# We specialize literal exponentiation here,
-# letting downstream users specialize f * f for custom domains
-# With f * f type-inferred, the type of f^2 would also be inferred.
-# This is a stopgap measure that might not be necessary in the future.
-Base.literal_pow(::typeof(^), f::Fun, ::Val{0}) = ones(cfstype(f), space(f))
-Base.literal_pow(::typeof(^), f::Fun, ::Val{1}) = f
-Base.literal_pow(::typeof(^), f::Fun, ::Val{2}) = f * f
-Base.literal_pow(::typeof(^), f::Fun, ::Val{3}) = f * f * f
-Base.literal_pow(::typeof(^), f::Fun, ::Val{4}) = f * f * f * f
 
 inv(f::Fun) = 1/f
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -505,7 +505,7 @@ end
                 blk = ApproxFunBase.block(t, i)
                 @test i ∈ ApproxFunBase.blockrange(t, blk)
                 @test vi == t[i]
-                @test findfirst(t, vi) == i
+                @test findfirst(vi, t) == i
             end
         end
         @testset "nD" begin
@@ -525,7 +525,7 @@ end
         v = collect(Iterators.take(t, 16))
         @test eltype(v) == eltype(t)
         @testset for (i, vi) in enumerate(v)
-            @test findfirst(t, vi) == i
+            @test findfirst(vi, t) == i
         end
     end
     @testset "cache" begin


### PR DESCRIPTION
With this, arbitrary integer powers of `Fun` are type-inferred:
```julia
julia> f = Fun(Chebyshev(0..1));

julia> @inferred (f -> f^10)(f);

julia> @inferred abs2(f);
```