### PR TITLE
Type-stability in 2d tensorizer iteration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.68"
+version = "0.7.69"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -546,7 +546,7 @@ end
 CachedIterator{T,IT}(it::IT, state) where {T,IT} = CachedIterator{T,IT}(it,T[],state,0)
 CachedIterator(it::IT) where IT = CachedIterator{eltype(it),IT}(it, ())
 
-function resize!(it::CachedIterator,n::Integer)
+function resize!(it::CachedIterator{T},n::Integer) where {T}
     m = it.length
     if n > m
         if n > length(it.storage)
@@ -559,10 +559,10 @@ function resize!(it::CachedIterator,n::Integer)
                 it.length = k-1
                 return it
             end
-            it.storage[k] = xst[1]
-            it.state = (xst[2],)
+            v::T, st = xst
+            it.storage[k] = v
+            it.state = (st,)
         end
-
         it.length = n
     end
     it
@@ -579,7 +579,7 @@ Base.keys(c::CachedIterator) = oneto(length(c))
 
 iterate(it::CachedIterator) = iterate(it,1)
 function iterate(it::CachedIterator,st::Int)
-    if  st == it.length + 1 && iterate(it.iterator,it.state...) === nothing
+    if  st > it.length && iterate(it.iterator,it.state...) === nothing
         nothing
     else
         (it[st],st+1)


### PR DESCRIPTION
On master
```julia
julia> t = ApproxFunBase.tensorizer(Chebyshev()^2);

julia> @btime first(ApproxFunBase.cache($t), 100);
  26.686 μs (702 allocations: 58.25 KiB)
```
This PR
```julia
julia> @btime first(ApproxFunBase.cache($t), 100);
  16.425 μs (502 allocations: 47.31 KiB)
```