### PR TITLE
Disable empty vector in findmindomain/findmaxrange

### DIFF
--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -240,7 +240,7 @@ function colstop(M::InterlaceOperator, j::Integer)
         for N = 1:size(M.ops,1)
             cs = colstop(M.ops[N,J],jj)::Int
             if cs > 0
-                K = max(K,findfirst(M.rangeinterlacer,(N,cs))::Int)
+                K = max(K,findfirst((N,cs), M.rangeinterlacer)::Int)
             end
         end
         K

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -494,7 +494,7 @@ for TYP in (:Matrix, :BandedMatrix, :RaggedMatrix)
             RT2 = _rettype(RT)
             BA::RT2 = strictconvert(RT, P.ops[end][krl[end, 1]:krl[end, 2], jr])
             for m = (length(P.ops)-1):-1:1
-                BA = strictconvert(RT, P.ops[m][krl[m, 1]:krl[m, 2], krl[m+1, 1]:krl[m+1, 2]]) * BA
+                BA = strictconvert(RT, P.ops[m][krl[m, 1]:krl[m, 2], krl[m+1, 1]:krl[m+1, 2]])::RT2 * BA
             end
 
             RT(BA)

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -48,11 +48,11 @@ rangespace(S::SpaceOperator) = S.rangespace
 
 ##TODO: Do we need both max and min?
 function findmindomainspace(ops)
-    mapreduce(domainspace, union, ops, init = UnsetSpace())
+    mapreduce(domainspace, union, ops)
 end
 
 function findmaxrangespace(ops)
-    mapreduce(rangespace, maxspace, ops, init = UnsetSpace())
+    mapreduce(rangespace, maxspace, ops)
 end
 
 


### PR DESCRIPTION
This improves type inference by some extent, as the result may be inferrable. This is an internal method, so the change should be ok.