### PR TITLE
BandedBlockBandedMatrix function barrier

### DIFF
--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -263,14 +263,7 @@ function BandedBlockBandedMatrix(::Type{Zeros}, S::SubOperator)
                                 rows,cols, (l,u), (λ-jsh,μ+ksh))
 end
 
-function BandedBlockBandedMatrix(::Type{Zeros}, S::SubOperator{<:Any,<:Any,Tuple{BlockRange1,BlockRange1}})
-    KR,JR = parentindices(S)
-    KO = parent(S)
-    l,u = blockbandwidths(KO)::Tuple{Int,Int}
-    λ,μ = subblockbandwidths(KO)::Tuple{Int,Int}
-
-    rt = rangespace(KO)
-    dt = domainspace(KO)
+function _BandedBlockBandedMatrixZeros(::Type{T}, KR, JR, (l,u), (λ,μ), rt, dt) where {T}
     J = first(JR)
     K = first(KR)
     bl_sh = Int(J) - Int(K)
@@ -278,8 +271,17 @@ function BandedBlockBandedMatrix(::Type{Zeros}, S::SubOperator{<:Any,<:Any,Tuple
     KBR = blocklengthrange(rt,KR)
     KJR = blocklengthrange(dt,JR)
 
-    BandedBlockBandedMatrix(Zeros{eltype(KO)}(sum(KBR),sum(KJR)),
-                                AbstractVector{Int}(KBR),AbstractVector{Int}(KJR), (l+bl_sh,u-bl_sh), (λ,μ))
+    BandedBlockBandedMatrix(Zeros{T}(sum(KBR),sum(KJR)),
+                                convert(AbstractVector{Int}, KBR),
+                                convert(AbstractVector{Int}, KJR),
+                                (l+bl_sh,u-bl_sh), (λ,μ))
+end
+function BandedBlockBandedMatrix(::Type{Zeros}, S::SubOperator{<:Any,<:Any,Tuple{BlockRange1,BlockRange1}})
+    KR,JR = parentindices(S)
+    KO = parent(S)
+    l,u = blockbandwidths(KO)::Tuple{Int,Int}
+    λ,μ = subblockbandwidths(KO)::Tuple{Int,Int}
+    _BandedBlockBandedMatrixZeros(eltype(KO), KR, JR, (l,u), (λ,μ), rangespace(KO), domainspace(KO))
 end
 
 

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -240,7 +240,7 @@ function colstop(M::InterlaceOperator, j::Integer)
         for N = 1:size(M.ops,1)
             cs = colstop(M.ops[N,J],jj)::Int
             if cs > 0
-                K = max(K,findfirst(M.rangeinterlacer,(N,cs))::Int)
+                K = max(K,findfirst((N,cs), M.rangeinterlacer)::Int)
             end
         end
         K

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -494,7 +494,7 @@ for TYP in (:Matrix, :BandedMatrix, :RaggedMatrix)
             RT2 = _rettype(RT)
             BA::RT2 = strictconvert(RT, P.ops[end][krl[end, 1]:krl[end, 2], jr])
             for m = (length(P.ops)-1):-1:1
-                BA = strictconvert(RT, P.ops[m][krl[m, 1]:krl[m, 2], krl[m+1, 1]:krl[m+1, 2]]) * BA
+                BA = strictconvert(RT, P.ops[m][krl[m, 1]:krl[m, 2], krl[m+1, 1]:krl[m+1, 2]])::RT2 * BA
             end
 
             RT(BA)

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -439,10 +439,10 @@ for TYP in (:Matrix, :BandedMatrix, :RaggedMatrix)
                     return $TYP(BandedMatrix(V))
                 end
             elseif isbandedblockbanded(P)
-                N = block(rangespace(P), last(parentindices(V)[1]))
-                M = block(domainspace(P), last(parentindices(V)[2]))
-                B = P[Block(1):N, Block(1):M]
-                return $TYP(view(B, parentindices(V)...), _colstops(V))
+                N = block(rangespace(P), last(parentindices(V)[1]))::Block{1,Int}
+                M = block(domainspace(P), last(parentindices(V)[2]))::Block{1,Int}
+                B = P[Block(1):N, Block(1):M]::AbstractMatrix{T}
+                return $TYP(view(B, parentindices(V)...), _colstops(V))::$TYP{T}
             end
 
             kr, jr = parentindices(V)

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -48,11 +48,11 @@ rangespace(S::SpaceOperator) = S.rangespace
 
 ##TODO: Do we need both max and min?
 function findmindomainspace(ops)
-    mapreduce(domainspace, union, ops, init = UnsetSpace())
+    mapreduce(domainspace, union, ops)
 end
 
 function findmaxrangespace(ops)
-    mapreduce(rangespace, maxspace, ops, init = UnsetSpace())
+    mapreduce(rangespace, maxspace, ops)
 end
 
 


### PR DESCRIPTION
This improves performance slightly
On master
```julia
julia> D = Derivative(Chebyshev()) ⊗ Derivative(Chebyshev());

julia> D2 = D[Fun((x,y) -> x^2*y^2, Chebyshev()^2)];

julia> DBv = view(D2, Block(1):Block(20), Block(1):Block(20));

julia> @btime BandedBlockBandedMatrix(Zeros, $DBv);
  6.338 μs (16 allocations: 104.77 KiB)
```
This PR
```julia
julia> @btime BandedBlockBandedMatrix(Zeros, $DBv);
  5.513 μs (11 allocations: 104.23 KiB)
```