### PR TITLE
Spaces in Conversion, Multiplication and Evaluation wrapper

### DIFF
--- a/ApproxFunBaseTest/Project.toml
+++ b/ApproxFunBaseTest/Project.toml
@@ -14,7 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ApproxFunBase = "0.5, 0.6, 0.7"
+ApproxFunBase = "0.5, 0.6, 0.7, 0.8"
 BandedMatrices = "0.16, 0.17"
 BlockArrays = "0.14, 0.15, 0.16"
 BlockBandedMatrices = "0.10, 0.11"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.75"
+version = "0.8.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.7.74"
+version = "0.7.75"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -645,6 +645,8 @@ macro wrapper(Wrap, forwarddomain = true, forwardrange = true)
     esc(ret)
 end
 
+unwrap(A::Operator) = iswrapper(A) ? A.op : A
+
 ## Standard Operators and linear algebra
 
 

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -611,16 +611,20 @@ end
 # use this for wrapper operators that have the same spaces but
 # not necessarily the same entries or structure
 #
-macro wrapperspaces(Wrap, forwarddomain = true)
-    fns = [:(ApproxFunBase.rangespace),:(ApproxFunBase.domain), :(ApproxFunBase.isconstop)]
+macro wrapperspaces(Wrap, forwarddomain = true, forwardrange = true)
+    fns = [:(ApproxFunBase.isconstop)]
     if forwarddomain
         fns = [fns; :(ApproxFunBase.domainspace)]
+    end
+    if forwardrange
+        fns = [fns; :(ApproxFunBase.rangespace)]
     end
     v = map(fns) do func
         :($func(D::$Wrap) = $func(D.op))
     end
     ret = quote
         $(v...)
+        ApproxFunBase.domain(D::$Wrap) = domain(domainspace(D))
     end
 
     esc(ret)
@@ -629,10 +633,10 @@ end
 
 # use this for wrapper operators that have the same entries and same spaces
 #
-macro wrapper(Wrap, forwarddomain = true)
+macro wrapper(Wrap, forwarddomain = true, forwardrange = true)
     ret = quote
         ApproxFunBase.@wrappergetindex($Wrap)
-        ApproxFunBase.@wrapperspaces($Wrap, $forwarddomain)
+        ApproxFunBase.@wrapperspaces($Wrap, $forwarddomain, $forwardrange)
 
         ApproxFunBase.iswrapper(::$Wrap) = true
     end

--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -90,15 +90,20 @@ choosedomainspace(M::ConcreteMultiplication{D,UnsetSpace},sp::Space) where {D} =
 
 diagm(a::Fun) = Multiplication(a)
 
-struct MultiplicationWrapper{D<:Space,S<:Space,O<:Operator,T} <: Multiplication{D,S,T}
+struct MultiplicationWrapper{D<:Space,S<:Space,T,O<:Operator{T}} <: Multiplication{D,S,T}
     f::VFun{D,T}
     op::O
     space::S
+
+    function MultiplicationWrapper{D,S,T,O}(f::Fun{D,T},op::O,space::S) where {D,S,T,O<:Operator{T}}
+        new{D,S,T,O}(f,op,space)
+    end
 end
 
 function MultiplicationWrapper(::Type{T}, f::Fun{D}, op::Operator,
         space::S = domainspace(op)) where {D,T,S<:Space}
-    MultiplicationWrapper{D,S,typeof(op),T}(f,op,space)
+    g = convert(VFun{D,T}, f)
+    MultiplicationWrapper{D,S,T,typeof(op)}(g,op,space)
 end
 function MultiplicationWrapper(f::Fun, op::Operator, space::Space = domainspace(op))
     MultiplicationWrapper(eltype(op), f, op, space)

--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -35,7 +35,7 @@ function defaultMultiplication(f::Fun,sp::Space)
     if csp==sp || !hasconversion(sp,csp)
         error("Implement Multiplication(::Fun{$(typeof(space(f)))},::$(typeof(sp)))")
     end
-    MultiplicationWrapper(f,Multiplication(f,csp)*Conversion(sp,csp))
+    MultiplicationWrapper(f, Multiplication(f,csp)*Conversion(sp,csp), sp)
 end
 
 Multiplication(f::Fun,sp::Space) = defaultMultiplication(f,sp)

--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -93,23 +93,26 @@ diagm(a::Fun) = Multiplication(a)
 struct MultiplicationWrapper{D<:Space,S<:Space,O<:Operator,T} <: Multiplication{D,S,T}
     f::VFun{D,T}
     op::O
+    space::S
 end
 
 function MultiplicationWrapper(::Type{T}, f::Fun{D}, op::Operator,
-        dspop::S = domainspace(op)) where {D,T,S<:Space}
-    MultiplicationWrapper{D,S,typeof(op),T}(f,op)
+        space::S = domainspace(op)) where {D,T,S<:Space}
+    MultiplicationWrapper{D,S,typeof(op),T}(f,op,space)
 end
-function MultiplicationWrapper(f::Fun, op::Operator, dspop::Space = domainspace(op))
-    MultiplicationWrapper(eltype(op), f, op, dspop)
+function MultiplicationWrapper(f::Fun, op::Operator, space::Space = domainspace(op))
+    MultiplicationWrapper(eltype(op), f, op, space)
 end
 
-@wrapper MultiplicationWrapper
+domainspace(M::MultiplicationWrapper) = M.space
+
+@wrapper MultiplicationWrapper false
 
 function convert(::Type{Operator{TT}},C::MultiplicationWrapper{S,V,O,T}) where {TT,S,V,O,T}
     if TT==T
         C
     else
-        MultiplicationWrapper(Fun{S,TT}(C.f),Operator{TT}(C.op))::Operator{TT}
+        MultiplicationWrapper(Fun{S,TT}(C.f),Operator{TT}(C.op), C.space)::Operator{TT}
     end
 end
 

--- a/src/Operators/functionals/Evaluation.jl
+++ b/src/Operators/functionals/Evaluation.jl
@@ -97,13 +97,12 @@ struct EvaluationWrapper{S<:Space,M,FS<:Operator,OT,T<:Number} <: Evaluation{T}
 end
 
 
-@wrapper EvaluationWrapper
+@wrapper EvaluationWrapper false
 EvaluationWrapper(sp::Space,x,order,func::Operator) =
     EvaluationWrapper{typeof(sp),typeof(x),typeof(func),typeof(order),eltype(func)}(sp,x,order,func)
 
 
 domainspace(E::Evaluation) = E.space
-domain(E::Evaluation) = domain(E.space)
 promotedomainspace(E::Evaluation,sp::Space) = Evaluation(sp,E.x,E.order)
 
 

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -612,7 +612,10 @@ end
 _unwrap_conversion(c) = c
 _unwrap_conversion(c::ConversionWrapper{<:TimesOperator}) = c.op
 
-*(A::Conversion, B::Conversion) = ConversionWrapper(TimesOperator(_unwrap_conversion(A), _unwrap_conversion(B)))
+function *(A::Conversion, B::Conversion)
+    T = TimesOperator(_unwrap_conversion(A), _unwrap_conversion(B))
+    ConversionWrapper(T, domainspace(B), rangespace(A))
+end
 *(A::Conversion, B::TimesOperator) = TimesOperator(A, B)
 *(A::TimesOperator, B::Conversion) = TimesOperator(A, B)
 *(A::Operator, B::Conversion) =

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -608,12 +608,8 @@ end
 
 
 # Conversions we always assume are intentional: no need to promote
-
-_unwrap_conversion(c) = c
-_unwrap_conversion(c::ConversionWrapper{<:TimesOperator}) = c.op
-
 function *(A::Conversion, B::Conversion)
-    T = TimesOperator(_unwrap_conversion(A), _unwrap_conversion(B))
+    T = TimesOperator(unwrap(A), unwrap(B))
     ConversionWrapper(T, domainspace(B), rangespace(A))
 end
 *(A::Conversion, B::TimesOperator) = TimesOperator(A, B)

--- a/src/PDE/PDE.jl
+++ b/src/PDE/PDE.jl
@@ -14,7 +14,7 @@ function Laplacian(d::BivariateSpace, k::Number)
     Dx2=Derivative(d, SVector{2}(2,0))
     Dy2=Derivative(d, SVector{2}(0,2))
     if k==1
-        LaplacianWrapper(Dx2+Dy2,d,k)
+        LaplacianWrapper(Dx2+Dy2,k,d)
     else
         @assert k > 0
         Δ=Laplacian(d,1)


### PR DESCRIPTION
With this, the following becomes type-inferred:
```julia
julia> @inferred (() -> domain(Evaluation(Chebyshev() + Ultraspherical(1), 0.1)))()
-1.0..1.0 (Chebyshev)
```