### PR TITLE
use NTuple{2,UnitRange{Int}}

### DIFF
--- a/src/LinearAlgebra/RaggedMatrix.jl
+++ b/src/LinearAlgebra/RaggedMatrix.jl
@@ -183,13 +183,13 @@ function axpy!(a, X::RaggedMatrix, Y::RaggedMatrix)
     Y
 end
 
-colstop(X::SubArray{T,2,RaggedMatrix{T},Tuple{UnitRange{Int},UnitRange{Int}}},
+colstop(X::SubArray{T,2,RaggedMatrix{T},NTuple{2,UnitRange{Int}}},
      j::Integer) where {T} = min(colstop(parent(X),j + first(parentindices(X)[2])-1) -
                                             first(parentindices(X)[1]) + 1,
                             size(X,1))
 
 function axpy!(a,X::RaggedMatrix,
-                    Y::SubArray{T,2,RaggedMatrix{T},Tuple{UnitRange{Int},UnitRange{Int}}}) where T
+                    Y::SubArray{T,2,RaggedMatrix{T},NTuple{2,UnitRange{Int}}}) where T
     if size(X) ≠ size(Y)
         throw(BoundsError())
     end

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -552,7 +552,7 @@ macro wrappergetindex(Wrap)
             ApproxFunBase.unwrap_axpy!(α,P,A)
 
         ApproxFunBase.mul_coefficients(A::$Wrap,b) = ApproxFunBase.mul_coefficients(A.op,b)
-        ApproxFunBase.mul_coefficients(A::ApproxFunBase.SubOperator{T,OP,Tuple{UnitRange{Int},UnitRange{Int}}},b) where {T,OP<:$Wrap} =
+        ApproxFunBase.mul_coefficients(A::ApproxFunBase.SubOperator{T,OP,NTuple{2,UnitRange{Int}}},b) where {T,OP<:$Wrap} =
             ApproxFunBase.mul_coefficients(view(parent(A).op,S.indexes[1],S.indexes[2]),b)
         ApproxFunBase.mul_coefficients(A::ApproxFunBase.SubOperator{T,OP},b) where {T,OP<:$Wrap} =
             ApproxFunBase.mul_coefficients(view(parent(A).op,S.indexes[1],S.indexes[2]),b)

--- a/src/Operators/banded/ToeplitzOperator.jl
+++ b/src/Operators/banded/ToeplitzOperator.jl
@@ -57,7 +57,7 @@ function toeplitz_getindex(cfs::AbstractVector{T},k::Integer,j::Integer) where T
     end
 end
 
-function BandedMatrix(S::SubOperator{T,ToeplitzOperator{T},Tuple{UnitRange{Int},UnitRange{Int}}}) where T
+function BandedMatrix(S::SubOperator{T,ToeplitzOperator{T},NTuple{2,UnitRange{Int}}}) where T
     ret = BandedMatrix(Zeros, S)
 
     kr,jr=parentindices(S)
@@ -121,7 +121,7 @@ getindex(T::HankelOperator,k::Integer,j::Integer) =
     hankel_getindex(T.coefficients,k,j)
 
 
-function BandedMatrix(S::SubOperator{T,HankelOperator{T},Tuple{UnitRange{Int},UnitRange{Int}}}) where T
+function BandedMatrix(S::SubOperator{T,HankelOperator{T},NTuple{2,UnitRange{Int}}}) where T
     ret=BandedMatrix(Zeros, S)
 
     kr,jr=parentindices(S)

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -332,7 +332,7 @@ for TYP in (:BandedMatrix, :BlockBandedMatrix, :BandedBlockBandedMatrix, :Ragged
                 :Matrix)
     @eval begin
         function $TYP(S::SubOperator{T,InterlaceOperator{T,1,SS,PS,DI,RI,BI},
-                            Tuple{UnitRange{Int},UnitRange{Int}}}) where {SS,PS,DI,RI,BI,T}
+                            NTuple{2,UnitRange{Int}}}) where {SS,PS,DI,RI,BI,T}
             kr,jr=parentindices(S)
             L=parent(S)
 
@@ -356,7 +356,7 @@ for TYP in (:BandedMatrix, :BlockBandedMatrix, :BandedBlockBandedMatrix, :Ragged
         end
 
         function $TYP(S::SubOperator{T,InterlaceOperator{T,2,SS,PS,DI,RI,BI},
-                      Tuple{UnitRange{Int},UnitRange{Int}}}) where {SS,PS,DI,RI,BI,T}
+                      NTuple{2,UnitRange{Int}}}) where {SS,PS,DI,RI,BI,T}
             kr,jr=parentindices(S)
             L=parent(S)
 

--- a/src/Operators/general/PartialInverseOperator.jl
+++ b/src/Operators/general/PartialInverseOperator.jl
@@ -109,7 +109,7 @@ end
 
 ## These are both hacks that apparently work
 
-function BandedMatrix(S::SubOperator{T,<:PartialInverseOperator,Tuple{UnitRange{Int},UnitRange{Int}}}) where {T}
+function BandedMatrix(S::SubOperator{T,<:PartialInverseOperator,NTuple{2,UnitRange{Int}}}) where {T}
     kr,jr = parentindices(S)
     P = parent(S)
     #ret = BandedMatrix{eltype(S)}(undef, size(S), bandwidths(S))

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -416,7 +416,7 @@ Evaluation(sp::TensorSpace,x::Tuple) = Evaluation(sp,SVector(x...))
 
 
 # it's faster to build the operators to the last b
-function mul_coefficients(A::SubOperator{T,KKO,Tuple{UnitRange{Int},UnitRange{Int}}}, b) where {T,KKO<:KroneckerOperator}
+function mul_coefficients(A::SubOperator{T,KKO,NTuple{2,UnitRange{Int}}}, b) where {T,KKO<:KroneckerOperator}
     P = parent(A)
     kr,jr = parentindices(A)
     dt,rt = domaintensorizer(P),rangetensorizer(P)

--- a/src/Spaces/QuotientSpace.jl
+++ b/src/Spaces/QuotientSpace.jl
@@ -262,7 +262,7 @@ for (gesdd, elty, relty) in ((:dgesdd_,:Float64,:Float64),
 end
 
 
-function BandedMatrix(S::SubOperator{T,ConcreteConversion{QuotientSpace{SP,O,D,R},SP,T},Tuple{UnitRange{Int},UnitRange{Int}}}) where {SP,O,D,R,T}
+function BandedMatrix(S::SubOperator{T,ConcreteConversion{QuotientSpace{SP,O,D,R},SP,T},NTuple{2,UnitRange{Int}}}) where {SP,O,D,R,T}
     kr,jr = parentindices(S)
     C = parent(S)
     #ret = BandedMatrix{eltype(S)}(undef, size(S), bandwidths(S))


### PR DESCRIPTION
Purely stylistic change to replace `Tuple{UnitRange{Int},UnitRange{Int}}` by `NTuple{2,UnitRange{Int}}`
