### PR TITLE
nospeicalize in default_Fun

### DIFF
--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -636,15 +636,7 @@ end
 
 ## Dynamic functions
 
-struct DFunction{F} <: Function
-    f :: F
-end
-(f::DFunction)(args...) = f.f(args...)
-
-hasnumargs(f::DFunction, k) = hasnumargs(f.f, k)
-
 dynamic(f) = f
-dynamic(f::Function) = DFunction(f) # Assume f has to compile every time
 
 
 # Matrix inputs

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -95,8 +95,9 @@ Fun(c::Number,d::Space) = c==0 ? c*zeros(prectype(d),d) : c*ones(prectype(d),d)
 function default_Fun(f, d::Space)
     _default_Fun(hasonearg(f) ? f : Base.splat(f), d)
 end
+@noinline warn_maxncoeff() = @warn "Maximum number of coefficients "*string(2^20+1)*" reached in constructing Fun."
 # In _default_Fun, we know that the function takes a single argument
-function _default_Fun(f, d::Space)
+function _default_Fun(@nospecialize(f), d::Space)
     isinf(dimension(d)) || return Fun(f,d,dimension(d))  # use exactly dimension number of sample points
 
     #TODO: reuse function values?
@@ -131,8 +132,7 @@ function _default_Fun(f, d::Space)
         end
     end
 
-    @warn "Maximum number of coefficients "*string(2^20+1)*" reached in constructing Fun."
-
+    warn_maxncoeff()
     Fun(f,d,2^21)
 end
 


### PR DESCRIPTION
This improves runtimes with anonymous functions significantly, with some hit to runtimes with named functions.
On master
```julia
julia> @time Fun(x->x^10, Chebyshev()); # First execution
  2.512688 seconds (2.89 M allocations: 190.151 MiB, 3.30% gc time, 99.40% compilation time)

julia> @time Fun(x->x^10, Chebyshev());
  0.263254 seconds (317.08 k allocations: 21.728 MiB, 11.46% gc time, 99.90% compilation time)

julia> @time Fun(x->x^12, Chebyshev());
  0.181304 seconds (318.51 k allocations: 21.836 MiB, 99.81% compilation time)

julia> _g(x) = x^10;

julia> @btime Fun($_g, Chebyshev());
  10.570 μs (27 allocations: 1.94 KiB)
```
This PR
```julia
julia> @time Fun(x->x^10, Chebyshev()); # First execution
  2.551733 seconds (3.65 M allocations: 256.496 MiB, 2.87% gc time, 99.59% compilation time)

julia> @time Fun(x->x^10, Chebyshev());
  0.074030 seconds (79.10 k allocations: 5.448 MiB, 20.95% gc time, 99.63% compilation time)

julia> @time Fun(x->x^12, Chebyshev());
  0.060065 seconds (80.99 k allocations: 5.540 MiB, 99.59% compilation time)

julia> _g(x) = x^10;

julia> @btime Fun($_g, Chebyshev());
  13.004 μs (43 allocations: 2.39 KiB)
```

I think this was the reason `DFunction` was used at one point, but that's unnecessary, as we only need to avoid specialization, and not type-inference.