### PR TITLE
improve type inference in caching

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Caching/banded.jl
+++ b/src/Caching/banded.jl
@@ -1,6 +1,7 @@
 function CachedOperator(::Type{BandedMatrix},op::Operator;padding::Bool=false)
     bw = bandwidths(op)
-    l,u = bw
+    l = first(bw)
+    # working on the tuples directly instead of the components helps with type-stability
     padding && (bw = bw .+ (0,l))
     data = BandedMatrix{eltype(op)}(undef, (0,0), bw)
     CachedOperator(op,data,size(data),domainspace(op),rangespace(op), bw .* (-1,1),padding)

--- a/src/Caching/banded.jl
+++ b/src/Caching/banded.jl
@@ -1,8 +1,9 @@
 function CachedOperator(::Type{BandedMatrix},op::Operator;padding::Bool=false)
-    l,u=bandwidths(op)
-    padding && (u+=l)
-    data = BandedMatrix{eltype(op)}(undef, (0,0), (l,u))
-    CachedOperator(op,data,size(data),domainspace(op),rangespace(op),(-l,u),padding)
+    bw = bandwidths(op)
+    l,u = bw
+    padding && (bw = bw .+ (0,l))
+    data = BandedMatrix{eltype(op)}(undef, (0,0), bw)
+    CachedOperator(op,data,size(data),domainspace(op),rangespace(op), bw .* (-1,1),padding)
 end
 
 

--- a/src/Caching/bandedblockbanded.jl
+++ b/src/Caching/bandedblockbanded.jl
@@ -2,6 +2,7 @@
 function CachedOperator(::Type{BandedBlockBandedMatrix}, op::Operator)
     lu = blockbandwidths(op)
     λμ = subblockbandwidths(op)
+    # working on the tuples directly instead of the components helps with type-stability
     data = BandedBlockBandedMatrix{eltype(op)}(undef,
         blocklengths(rangespace(op))[1:0],blocklengths(domainspace(op))[1:0],
         lu, λμ)

--- a/src/Caching/bandedblockbanded.jl
+++ b/src/Caching/bandedblockbanded.jl
@@ -1,12 +1,12 @@
 
 function CachedOperator(::Type{BandedBlockBandedMatrix}, op::Operator)
-    l,u = blockbandwidths(op)
-    λ,μ = subblockbandwidths(op)
+    lu = blockbandwidths(op)
+    λμ = subblockbandwidths(op)
     data = BandedBlockBandedMatrix{eltype(op)}(undef,
         blocklengths(rangespace(op))[1:0],blocklengths(domainspace(op))[1:0],
-        (l,u), (λ,μ))
+        lu, λμ)
 
-    CachedOperator(op,data,size(data),domainspace(op),rangespace(op),(-l,u),false)
+    CachedOperator(op,data,size(data),domainspace(op),rangespace(op),lu .* (-1,1),false)
 end
 
 # Grow cached operator

--- a/src/Caching/blockbanded.jl
+++ b/src/Caching/blockbanded.jl
@@ -71,12 +71,12 @@ diagblockshift(op::Operator) = diagblockshift(blocklengths(domainspace(op)),bloc
 
 
 function CachedOperator(::Type{BlockBandedMatrix},op::Operator;padding::Bool=false)
-    l,u=blockbandwidths(op)
+    lu=blockbandwidths(op)
     padding && (u+=l+diagblockshift(op))
     data=BlockBandedMatrix{eltype(op)}(undef,
                                         Vector{Int}(), Vector{Int}(),
-                                        (l,u))
-    CachedOperator(op,data,(0,0),domainspace(op),rangespace(op),(-l,u),padding)
+                                        lu)
+    CachedOperator(op,data,(0,0),domainspace(op),rangespace(op),lu .* (-1,1),padding)
 end
 
 

--- a/src/Caching/blockbanded.jl
+++ b/src/Caching/blockbanded.jl
@@ -73,7 +73,7 @@ diagblockshift(op::Operator) = diagblockshift(blocklengths(domainspace(op)),bloc
 function CachedOperator(::Type{BlockBandedMatrix},op::Operator;padding::Bool=false)
     lu=blockbandwidths(op)
     l = first(lu)
-    if padding
+    if padding # working on the tuple helps with type-stability
         lu = lu .+ (0,l+diagblockshift(op))
     end
     data = BlockBandedMatrix{eltype(op)}(undef, Int[], Int[], lu)

--- a/src/Caching/blockbanded.jl
+++ b/src/Caching/blockbanded.jl
@@ -72,10 +72,11 @@ diagblockshift(op::Operator) = diagblockshift(blocklengths(domainspace(op)),bloc
 
 function CachedOperator(::Type{BlockBandedMatrix},op::Operator;padding::Bool=false)
     lu=blockbandwidths(op)
-    padding && (u+=l+diagblockshift(op))
-    data=BlockBandedMatrix{eltype(op)}(undef,
-                                        Vector{Int}(), Vector{Int}(),
-                                        lu)
+    l = first(lu)
+    if padding
+        lu = lu .+ (0,l+diagblockshift(op))
+    end
+    data = BlockBandedMatrix{eltype(op)}(undef, Int[], Int[], lu)
     CachedOperator(op,data,(0,0),domainspace(op),rangespace(op),lu .* (-1,1),padding)
 end
 


### PR DESCRIPTION
With this, the following (among others) becomes a small union:
```julia
julia> C = Conversion(Chebyshev(), Ultraspherical(1.0));

julia> @code_warntype ApproxFunBase.CachedOperator(BandedMatrix, C, padding=false)
MethodInstance for Core.kwcall(::NamedTuple{(:padding,), Tuple{Bool}}, ::Type{ApproxFunBase.CachedOperator}, ::Type{BandedMatrix}, ::ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Float64})
  from kwcall(::Any, ::Type{ApproxFunBase.CachedOperator}, ::Type{BandedMatrix}, op::Operator) @ ApproxFunBase ~/Dropbox/JuliaPackages/ApproxFunBase/src/Caching/banded.jl:1
Arguments
  _::Core.Const(Core.kwcall)
  @_2::NamedTuple{(:padding,), Tuple{Bool}}
  @_3::Type{ApproxFunBase.CachedOperator}
  @_4::Type{BandedMatrix}
  op::ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Float64}
Locals
  padding::Union{}
  @_7::Bool
Body::Union{ApproxFunBase.CachedOperator{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Float64}, Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Tuple{Int64, Int64}}, ApproxFunBase.CachedOperator{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Float64}, Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Tuple{Int64, Infinities.InfiniteCardinal{0}}}}
1 ──       Core.NewvarNode(:(padding))
│          Core.NewvarNode(:(@_7))
│    %3  = Core.isdefined(@_2, :padding)::Core.Const(true)
└───       goto #6 if not %3
2 ── %5  = Core.getfield(@_2, :padding)::Bool
│    %6  = (%5 isa ApproxFunBase.Bool)::Core.Const(true)
└───       goto #4 if not %6
3 ──       goto #5
4 ──       Core.Const(:(%new(Core.TypeError, Symbol("keyword argument"), :padding, ApproxFunBase.Bool, %5)))
└───       Core.Const(:(Core.throw(%9)))
5 ┄─       (@_7 = %5)
└───       goto #7
6 ──       Core.Const(:(@_7 = false))
7 ┄─ %14 = @_7::Bool
│    %15 = (:padding,)::Core.Const((:padding,))
│    %16 = Core.apply_type(Core.NamedTuple, %15)::Core.Const(NamedTuple{(:padding,)})
│    %17 = Base.structdiff(@_2, %16)::Core.Const(NamedTuple())
│    %18 = Base.pairs(%17)::Core.Const(Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}())
│    %19 = Base.isempty(%18)::Core.Const(true)
└───       goto #9 if not %19
8 ──       goto #10
9 ──       Core.Const(:(Base.kwerr(@_2, @_3, @_4, op)))
10 ┄ %23 = ApproxFunBase.:(var"#CachedOperator#586")(%14, @_3, @_4, op)::Union{ApproxFunBase.CachedOperator{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Float64}, Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Tuple{Int64, Int64}}, ApproxFunBase.CachedOperator{Float64, BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}}, ApproxFunBase.ConcreteConversion{Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Float64}, Chebyshev{ChebyshevInterval{Float64}, Float64}, Ultraspherical{Float64, ChebyshevInterval{Float64}, Float64}, Tuple{Int64, Infinities.InfiniteCardinal{0}}}}
└───       return %23
```