### PR TITLE
Precompute bandwidth in sumspace deriv

### DIFF
--- a/src/Spaces/ProductSpaceOperators.jl
+++ b/src/Spaces/ProductSpaceOperators.jl
@@ -299,7 +299,8 @@ function Multiplication(f::Fun{<:PiecewiseSpace}, sp::PiecewiseSpace)
     p=perm(domain(f).domains,domain(sp).domains)  # sort f
     vf=components(f)[p]
     t = map(Multiplication,vf,sp.spaces)
-    O = InterlaceOperator_Diagonal(t, sp)
+    D = Diagonal(convert_vector_or_svector(t))
+    O = InterlaceOperator(D, PiecewiseSpace)
     MultiplicationWrapper(f, O)
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -158,7 +158,7 @@ function show(io::IO,ss::PiecewiseSpace)
     end
     show(io,s[1])
     for sp in s[2:end]
-        print(io,"⨄")
+        print(io," ⨄ ")
         show(io,sp)
     end
     if length(s) == 1


### PR DESCRIPTION
After this, the following becomes type-stable:
```julia
julia> @inferred Derivative(Chebyshev()+Legendre())
DerivativeWrapper : Chebyshev() ⊕ Legendre() → Ultraspherical(1) ⊕ Jacobi(1,1)
 0.0  0.0  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   0.0  0.0  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   0.0  0.0  2.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   0.0  0.0  1.5   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   0.0  0.0  3.0   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  2.0   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  4.0   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  2.5  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱

julia> @inferred Derivative(Chebyshev(0..1) + Legendre(1..2))
DerivativeWrapper : Chebyshev(0..1) ⨄ Legendre(1..2) → Ultraspherical(1,0..1) ⊕ Jacobi(1,1,1..2)
 0.0  0.0  2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   0.0  0.0  2.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   0.0  0.0  4.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   0.0  0.0  3.0   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   0.0  0.0  6.0   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  4.0   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  8.0   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  5.0  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
```
