### PR TITLE
parameterize almostbandedmatrix

### DIFF
--- a/src/Caching/almostbanded.jl
+++ b/src/Caching/almostbanded.jl
@@ -176,7 +176,7 @@ end
 
 # Grow cached interlace operator
 
-function resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},<:InterlaceOperator{T,1}},
+function resizedata!(co::CachedOperator{T,<:AlmostBandedMatrix{T},<:InterlaceOperator{T,1}},
         n::Integer,::Colon) where {T<:Number}
     if n ≤ co.datasize[1]
         return co
@@ -210,7 +210,7 @@ end
 
 
 
-function resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},<:InterlaceOperator{T,2}},
+function resizedata!(co::CachedOperator{T,<:AlmostBandedMatrix{T},<:InterlaceOperator{T,2}},
         n::Integer,::Colon) where {T<:Number}
     if n ≤ co.datasize[1]
         return co
@@ -257,11 +257,11 @@ function resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},<:InterlaceOpera
 end
 
 
-resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},<:InterlaceOperator{T,1}},
+resizedata!(co::CachedOperator{T,<:AlmostBandedMatrix{T},<:InterlaceOperator{T,1}},
     n::Integer,m::Integer) where {T<:Number} = resizedata!(co,max(n,m+bandwidth(co.data.bands,1)),:)
 
 
-resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},<:InterlaceOperator{T,2}},
+resizedata!(co::CachedOperator{T,<:AlmostBandedMatrix{T},<:InterlaceOperator{T,2}},
     n::Integer,m::Integer) where {T<:Number} = resizedata!(co,max(n,m+bandwidth(co.data.bands,1)),:)
 
 
@@ -273,16 +273,14 @@ resizedata!(co::CachedOperator{T,AlmostBandedMatrix{T},<:InterlaceOperator{T,2}}
 ## QR
 
 
-function QROperator(R::CachedOperator{T,AlmostBandedMatrix{T}}) where T
+function QROperator(R::CachedOperator{T,<:AlmostBandedMatrix{T}}) where T
     M = R.data.bands.l+1   # number of diag+subdiagonal bands
     H = Matrix{T}(undef,M,100)
     QROperator(R,H,0)
 end
 
 
-function resizedata!(QR::QROperator{CachedOperator{T,AlmostBandedMatrix{T},
-                                                  MM,DS,RS,BI}},
-         ::Colon,col) where {T,MM,DS,RS,BI}
+function resizedata!(QR::QROperator{<:CachedOperator{T,<:AlmostBandedMatrix{T}}}, ::Colon, col) where {T}
     if col ≤ QR.ncols
         return QR
     end
@@ -346,9 +344,7 @@ end
 
 # BLAS versions, requires BlasFloat
 
-function resizedata!(QR::QROperator{CachedOperator{T,AlmostBandedMatrix{T},
-                                       MM,DS,RS,BI}},
-::Colon,col) where {T<:BlasFloat,MM,DS,RS,BI}
+function resizedata!(QR::QROperator{<:CachedOperator{T,<:AlmostBandedMatrix{T}}}, ::Colon, col) where {T<:BlasFloat}
     if col ≤ QR.ncols
         return QR
     end
@@ -417,8 +413,9 @@ end
 ## back substitution
 # loop to avoid ambiguity with AbstractTRiangular
 for ArrTyp in (:AbstractVector, :AbstractMatrix)
-    @eval function ldiv!(U::UpperTriangular{T, SubArray{T, 2, AlmostBandedMatrix{T}, Tuple{UnitRange{Int}, UnitRange{Int}}, false}},
-                       u::$ArrTyp{T}) where T
+    @eval function ldiv!(U::UpperTriangular{T,<:SubArray{T, 2, <:AlmostBandedMatrix{T}, NTuple{2,UnitRange{Int}}, false}},
+                u::$ArrTyp{T}) where T
+
         n = size(u,1)
         n == size(U,1) || throw(DimensionMismatch())
 

--- a/src/LinearAlgebra/AlmostBandedMatrix.jl
+++ b/src/LinearAlgebra/AlmostBandedMatrix.jl
@@ -2,14 +2,14 @@
 
 
 
-struct AlmostBandedMatrix{T} <: AbstractMatrix{T}
-    bands::BandedMatrix{T}
+struct AlmostBandedMatrix{T,B<:BandedMatrix{T}} <: AbstractMatrix{T}
+    bands::B
     fill::LowRankMatrix{T}
     function AlmostBandedMatrix{T}(bands::BandedMatrix{T}, fill::LowRankMatrix{T}) where T
         if size(bands) ≠ size(fill)
             error("Data and fill must be compatible size")
         end
-        new{T}(bands,fill)
+        new{T,typeof(bands)}(bands,fill)
     end
 end
 
@@ -33,8 +33,6 @@ end
 
 
 size(A::AlmostBandedMatrix) = size(A.bands)
-Base.IndexStyle(::Type{ABM}) where {ABM<:AlmostBandedMatrix} =
-    IndexCartesian()
 
 
 function getindex(B::AlmostBandedMatrix,k::Integer,j::Integer)

--- a/src/LinearAlgebra/AlmostBandedMatrix.jl
+++ b/src/LinearAlgebra/AlmostBandedMatrix.jl
@@ -26,9 +26,9 @@ AlmostBandedMatrix{T}(Z::Zeros, lu::NTuple{2,Integer}, r::Integer) where {T} =
 AlmostBandedMatrix(Z::AbstractMatrix, lu::NTuple{2,Integer}, r::Integer) =
     AlmostBandedMatrix{eltype(Z)}(Z, lu, r)
 
-for MAT in (:AlmostBandedMatrix, :AbstractMatrix, :AbstractArray)
+for MAT in (:AlmostBandedMatrix, :AbstractMatrix)
     @eval convert(::Type{$MAT{T}}, A::AlmostBandedMatrix) where {T} =
-        AlmostBandedMatrix(AbstractMatrix{T}(A.bands),AbstractMatrix{T}(A.fill))
+        AlmostBandedMatrix(convert(AbstractMatrix{T}, A.bands), convert(AbstractMatrix{T}, A.fill))
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,6 +163,10 @@ end
     A = ApproxFunBase.AlmostBandedMatrix{Float64}(Zeros(4,4), (1,1), 2)
     sz = @inferred size(A)
     @test sz == (4,4)
+    @test convert(AbstractArray{Float64}, A) == A
+    AInt = convert(AbstractArray{Int}, A)
+    @test AInt isa AbstractArray{Int}
+    @test AInt == A
 end
 
 @testset "DiracDelta sampling" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,7 +160,9 @@ end
 end
 
 @testset "AlmostBandedMatrix" begin
-    @inferred (B -> B.bands)(ApproxFunBase.AlmostBandedMatrix{Float64}(Zeros(4,4), (1,1), 2))
+    A = ApproxFunBase.AlmostBandedMatrix{Float64}(Zeros(4,4), (1,1), 2)
+    sz = @inferred size(A)
+    @test sz == (4,4)
 end
 
 @testset "DiracDelta sampling" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,6 +159,10 @@ end
     @test ApproxFunBase.blockbandwidths(FiniteOperator([1 2; 3 4],S,S)) == (0,0)
 end
 
+@testset "AlmostBandedMatrix" begin
+    @inferred (B -> B.bands)(ApproxFunBase.AlmostBandedMatrix{Float64}(Zeros(4,4), (1,1), 2))
+end
+
 @testset "DiracDelta sampling" begin
     δ = 0.3DiracDelta(0.1) + 3DiracDelta(2.3)
     Random.seed!(0)


### PR DESCRIPTION
Fix
```julia
julia> @inferred (B -> B.bands)(ApproxFunBase.AlmostBandedMatrix{Float64}(Zeros(4,4), (1,1), 2))
ERROR: return type BandedMatrices.BandedMatrix{Float64, Matrix{Float64}, Base.OneTo{Int64}} does not match inferred return type BandedMatrices.BandedMatrix{Float64}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[9]:1
```