### PR TITLE
interlace coefficients by blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -372,20 +372,17 @@ function interlace(a::AbstractVector, b::AbstractVector, (ncomponents_a, ncompon
     # Fourth example: if a = [1,2,3,4,11,12] and b = [5], the result would be
     # [1,2, 5, 3,4, 0, 11,12]. In this case, b is padded to [5,0]
 
-    nblk_a, ra = divrem(length(a), ncomponents_a)
-    nblk_a += !iszero(ra)
-    pad_a = pad(a, ncomponents_a * nblk_a)
-    nblk_b, rb = divrem(length(b), ncomponents_b)
-    nblk_b += !iszero(rb)
-    pad_b = pad(b, ncomponents_b * nblk_b)
+    nblk_a = cld(length(a), ncomponents_a)
+    nblk_b = cld(length(b), ncomponents_b)
 
     if nblk_b >= nblk_a
-        pad_a = pad(pad_a, ncomponents_a * nblk_b)
         nblk_a = nblk_b
     elseif nblk_a - 1 > nblk_b
-        pad_b = pad(pad_b, ncomponents_b * (nblk_a-1))
         nblk_b = nblk_a-1
     end
+
+    pad_a = pad(a, ncomponents_a * nblk_a)
+    pad_b = pad(b, ncomponents_b * nblk_b)
 
     blksz_a = Fill(ncomponents_a, nblk_a)
     aPBlk = PseudoBlockArray(pad_a, blksz_a)

--- a/src/Spaces/Spaces.jl
+++ b/src/Spaces/Spaces.jl
@@ -8,7 +8,12 @@ include("QuotientSpace.jl")
 
 
 ⊕(A::Space,B::Space) = domainscompatible(A,B) ? SumSpace(A,B) : PiecewiseSpace(A,B)
-⊕(f::Fun,g::Fun) = Fun(space(f) ⊕ space(g), interlace(coefficients(f),coefficients(g)))
+function ⊕(f::Fun,g::Fun)
+    S1 = space(f)
+    S2 = space(g)
+    nc = map(ncomponents, (S1,S2))
+    Fun(S1 ⊕ S2, interlace(coefficients(f),coefficients(g), nc))
+end
 
 ⊕(f::Fun,g::Fun,h::Fun...) = ⊕((f ⊕ g), h...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,18 @@ end
 
         @test ApproxFunBase.interlace(collect(6:10),collect(1:5)) == ApproxFunBase.interlace!(collect(1:10),0)
         @test ApproxFunBase.interlace(collect(1:5),collect(6:10)) == ApproxFunBase.interlace!(collect(1:10),1)
+
+        # if one or more space is a SumSpace, we need to interlace blocks
+        @test ApproxFunBase.interlace([1,2,3], [5,6,7,8], (2,1)) == [1,2, 5, 3,0, 6, 0,0, 7, 0,0, 8]
+        @test ApproxFunBase.interlace([1,2,3], [5,6], (2,1)) == [1,2, 5, 3,0, 6]
+        @test ApproxFunBase.interlace([1,2,3], [5], (2,1)) == [1,2, 5, 3]
+        @test ApproxFunBase.interlace([1,2,3,4,11,12], [5], (2,1)) == [1,2, 5, 3,4, 0, 11,12]
+
+        @test ApproxFunBase.interlace([1,2,3], [5,6,7,8], (1,2)) == [1, 5,6, 2, 7,8, 3]
+        @test ApproxFunBase.interlace([1,2,3], [5,6], (1,2)) == [1, 5,6, 2, 0,0, 3]
+        @test ApproxFunBase.interlace([1,2,3], [5], (1,2)) == [1, 5,0, 2, 0,0, 3]
+
+        @test ApproxFunBase.interlace([1,2,3], [5,6,7,8], (2,2)) == [1,2, 5,6, 3,0, 7,8]
     end
 
     @testset "Iterators" begin


### PR DESCRIPTION
Fix a bug in `interlace` if the spaces have multiple components. In that case, the coefficients need to be interlaced block-wise.

After this, and a corresponding fix to `ApproxFunFourier`, the following works:
```julia
julia> f = Fun(θ->1+cos(θ), Fourier())
Fun(Fourier(【0.0,6.283185307179586❫), [1.0, 1.02893e-16, 1.0])

julia> g = integrate(f)
Fun(CosSpace(【0.0,6.283185307179586❫) ⊕ Chebyshev(0.0..6.283185307179586) ⊕ SinSpace(【0.0,6.283185307179586❫), [0.0, 3.14159, 1.0, -1.02893e-16, 3.14159])

julia> g(0.4) ≈ 0.4 + sin(0.4)
true
```