### PR TITLE
store isafunctional in TimesOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.13"
+version = "0.8.14"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
Also, propagate constants aggressively in the TimesOperator constructor. This makes the following type-stable:
```julia
julia> x = Fun();

julia> Σ = DefiniteIntegral(Chebyshev());

julia> @inferred ((x,Σ) -> x*Σ[x])(x,Σ);
```