### PR TITLE
Fix space promotion in timesoperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.18"
+version = "0.8.19"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -224,7 +224,8 @@ axpy!(α, S::SubOperator{T,OP}, A::AbstractMatrix) where {T,OP<:ConstantTimesOpe
 function check_times(ops)
     for k = 1:length(ops)-1
         size(ops[k], 2) == size(ops[k+1], 1) || throw(ArgumentError("incompatible operator sizes"))
-        spacescompatible(domainspace(ops[k]), rangespace(ops[k+1])) || throw(ArgumentError("incompatible spaces at index $k"))
+        spacescompatible(domainspace(ops[k]), rangespace(ops[k+1])) ||
+            throw(ArgumentError("incompatible spaces at index $k, received $(domainspace(ops[k])) and $(rangespace(ops[k+1]))"))
     end
     return nothing
 end
@@ -768,7 +769,8 @@ function promotedomainspace(P::TimesOperator, sp::Space, cursp::Space)
     if sp == cursp
         P
     elseif length(P.ops) == 2
-        P.ops[1] * promotedomainspace(P.ops[end], sp)
+        A = promotedomainspace(P.ops[end], sp)
+        promotedomainspace(P.ops[1], rangespace(A)) * A
     else
         promotetimes([P.ops[1:end-1]; promotedomainspace(P.ops[end], sp)], sp)
     end


### PR DESCRIPTION
After this, the following works:
```julia
julia> X = Multiplication(Fun(Legendre()), NormalizedLegendre()) → Jacobi(2,2)
TimesOperator : NormalizedLegendre() → Jacobi(2,2)
 0.0       0.174964  0.0          -0.178174    0.0         0.0507621    ⋅           ⋅           ⋅           ⋅         ⋅
 0.235702  0.0       3.15416e-17   0.0        -0.149992    0.0         0.0594291    ⋅           ⋅           ⋅         ⋅
  ⋅        0.174964  0.0          -0.0364447   0.0        -0.140572    0.0         0.067029     ⋅           ⋅         ⋅
  ⋅         ⋅        0.158114      0.0        -0.0543928   0.0        -0.137281    0.0         0.0738763    ⋅         ⋅
  ⋅         ⋅         ⋅            0.151178    0.0        -0.0663291   0.0        -0.136687    0.0         0.0801565  ⋅
  ⋅         ⋅         ⋅             ⋅          0.148344    0.0        -0.07551     0.0        -0.137477    0.0        ⋱
  ⋅         ⋅         ⋅             ⋅           ⋅          0.1476      0.0        -0.0831563   0.0        -0.139047   ⋱
  ⋅         ⋅         ⋅             ⋅           ⋅           ⋅          0.148048    0.0        -0.0898326   0.0        ⋱
  ⋅         ⋅         ⋅             ⋅           ⋅           ⋅           ⋅          0.149225    0.0        -0.0958393  ⋱
  ⋅         ⋅         ⋅             ⋅           ⋅           ⋅           ⋅           ⋅          0.150867    0.0        ⋱
  ⋅         ⋅         ⋅             ⋅           ⋅           ⋅           ⋅           ⋅           ⋅           ⋱         ⋱

julia> Y = X : Legendre()
TimesOperator : Legendre() → Jacobi(2,2)
 0.0       0.142857   0.0          -0.0952381   0.0         0.021645     ⋅           ⋅           ⋅           ⋅         ⋅
 0.333333  0.0       -6.16791e-19   0.0        -0.0707071   0.0         0.02331      ⋅           ⋅           ⋅         ⋅
  ⋅        0.142857   0.0          -0.0194805   0.0        -0.0599401   0.0         0.0244755    ⋅           ⋅         ⋅
  ⋅         ⋅         0.1           0.0        -0.025641    0.0        -0.0538462   0.0         0.0253394    ⋅         ⋅
  ⋅         ⋅          ⋅            0.0808081   0.0        -0.0282828   0.0        -0.0499109   0.0         0.0260062  ⋅
  ⋅         ⋅          ⋅             ⋅          0.0699301   0.0        -0.0296174   0.0        -0.0471541   0.0        ⋱
  ⋅         ⋅          ⋅             ⋅           ⋅          0.0629371   0.0        -0.0303644   0.0        -0.0451128  ⋱
  ⋅         ⋅          ⋅             ⋅           ⋅           ⋅          0.0580694   0.0        -0.0308123   0.0        ⋱
  ⋅         ⋅          ⋅             ⋅           ⋅           ⋅           ⋅          0.0544892   0.0        -0.0310944  ⋱
  ⋅         ⋅          ⋅             ⋅           ⋅           ⋅           ⋅           ⋅          0.051747    0.0        ⋱
  ⋅         ⋅          ⋅             ⋅           ⋅           ⋅           ⋅           ⋅           ⋅           ⋱         ⋱
```