### PR TITLE
Add and export `Conversion_normalizedspace`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.21"
+version = "0.8.22"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/Conversion.jl
+++ b/src/Operators/banded/Conversion.jl
@@ -86,6 +86,9 @@ function Conversion_maybeconcrete(sp, csp, v::Val{:backward})
     end
 end
 
+Conversion_tonormalizedspace(S::Space) = Conversion_maybeconcrete(normalizedspace(S), S, Val(:backward))
+Conversion_fromnormalizedspace(S::Space) = Conversion_maybeconcrete(normalizedspace(S), S, Val(:forward))
+
 """
     Conversion(fromspace::Space, tospace::Space)
 

--- a/src/Operators/banded/Conversion.jl
+++ b/src/Operators/banded/Conversion.jl
@@ -1,4 +1,4 @@
-export Conversion
+export Conversion, Conversion_normalizedspace
 
 abstract type Conversion{T}<:Operator{T} end
 
@@ -86,8 +86,50 @@ function Conversion_maybeconcrete(sp, csp, v::Val{:backward})
     end
 end
 
-Conversion_tonormalizedspace(S::Space) = Conversion_maybeconcrete(normalizedspace(S), S, Val(:backward))
-Conversion_fromnormalizedspace(S::Space) = Conversion_maybeconcrete(normalizedspace(S), S, Val(:forward))
+"""
+    Conversion_normalizedspace(S::Space, ::Val{:forward})
+
+Return `Conversion(S, normalizedspace(S))`. This may be concretely inferred for orthogonal polynomial spaces.
+
+    Conversion_normalizedspace(S::Space, ::Val{:backward})
+
+Return `Conversion(normalizedspace(S), S)`. This may be concretely inferred for orthogonal polynomial spaces.
+
+# Examples
+```jldoctest
+julia> Conversion_normalizedspace(Chebyshev(), Val(:forward))
+ConcreteConversion : Chebyshev() → NormalizedChebyshev()
+ 1.77245   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
+  ⋅       1.25331   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
+  ⋅        ⋅       1.25331   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
+  ⋅        ⋅        ⋅       1.25331   ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
+  ⋅        ⋅        ⋅        ⋅       1.25331   ⋅        ⋅        ⋅        ⋅        ⋅       ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅       1.25331   ⋅        ⋅        ⋅        ⋅       ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       1.25331   ⋅        ⋅        ⋅       ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       1.25331   ⋅        ⋅       ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       1.25331   ⋅       ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       1.25331  ⋅
+  ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅        ⋅       ⋱
+
+julia> Conversion_normalizedspace(Chebyshev(), Val(:backward))
+ConcreteConversion : NormalizedChebyshev() → Chebyshev()
+ 0.56419   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
+  ⋅       0.797885   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
+  ⋅        ⋅        0.797885   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
+  ⋅        ⋅         ⋅        0.797885   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
+  ⋅        ⋅         ⋅         ⋅        0.797885   ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
+  ⋅        ⋅         ⋅         ⋅         ⋅        0.797885   ⋅         ⋅         ⋅         ⋅        ⋅
+  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅        0.797885   ⋅         ⋅         ⋅        ⋅
+  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.797885   ⋅         ⋅        ⋅
+  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.797885   ⋅        ⋅
+  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.797885  ⋅
+  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋱
+```
+"""
+function Conversion_normalizedspace(S::Space, v::Union{Val{:forward}, Val{:backward}})
+    vflip = v isa Val{:forward} ? Val(:backward) : Val(:forward)
+    Conversion_maybeconcrete(normalizedspace(S), S, vflip)
+end
 
 """
     Conversion(fromspace::Space, tospace::Space)


### PR DESCRIPTION
This provides a unified way to construct `Conversion` operators to and from normalized spaces, on interval/segment as well as piecewise domains. The main advantage of this function over `Conversion` is that it skips the space check, and therefore it may improve type-stability. This is primarily meant for internal usage.

```julia
julia> Conversion_normalizedspace(Chebyshev(0..1), Val(:forward))
ConcreteConversion : Chebyshev(0..1) → NormalizedChebyshev(0..1)
 1.25331   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅       0.886227   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅        0.886227   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅        0.886227   ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅        0.886227   ⋅         ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅        0.886227   ⋅         ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅        0.886227   ⋅         ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.886227   ⋅         ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.886227   ⋅        ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        0.886227  ⋅
  ⋅        ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅         ⋅        ⋱

julia> using Test

julia> @inferred Conversion_normalizedspace(Chebyshev(0..1), Val(:forward));

julia> @inferred Conversion(Chebyshev(0..1), NormalizedChebyshev(0..1));
ERROR: return type ApproxFunBase.ConcreteConversion{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, NormalizedChebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Float64} does not match inferred return type Union{ApproxFunBase.ConcreteConversion{Chebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, NormalizedChebyshev{IntervalSets.ClosedInterval{Int64}, Float64}, Float64}, ApproxFunBase.ConversionWrapper{_A, _B, Float64, TimesOperator{Float64, Tuple{Int64, Int64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Operator{Float64}, Tuple{Int64, Int64}, Tuple{Int64, Int64}}} where {_A<:Space, _B<:Space}}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[5]:1
```