### PR TITLE
improve type-inference in mul_coefficients

### DIFF
--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -698,7 +698,7 @@ for mulcoeff in [:mul_coefficients, :mul_coefficients!]
     @eval begin
         function $mulcoeff(A::Operator, b)
             n = size(b, 1)
-            ret = n > 0 ? $mulcoeff(view(A, FiniteRange, 1:n), b) : b
+            ret = n > 0 ? oftype(b, $mulcoeff(view(A, FiniteRange, 1:n), b)) : b
         end
 
         function $mulcoeff(A::TimesOperator, b)

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -699,7 +699,8 @@ function mulcoeff_maybeconvert(f, A, b, n)
 end
 function mulcoeff_maybeconvert(f, A, b::Vector, n)
     v = _mulcoeff_maybeconvert(f, A, b, n)
-    oftype(b, v)
+    T = promote_type(eltype(A), eltype(b))
+    convert(Vector{T}, v)
 end
 
 ## Operations

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -691,14 +691,23 @@ end
 
 
 
-
+function _mulcoeff_maybeconvert(f::F, A, b, n) where {F}
+    n > 0 ? f(view(A, FiniteRange, 1:n)) : b
+end
+function mulcoeff_maybeconvert(f, A, b, n)
+    _mulcoeff_maybeconvert(f, A, b, n)
+end
+function mulcoeff_maybeconvert(f, A, b::Vector, n)
+    v = _mulcoeff_maybeconvert(f, A, b, n)
+    oftype(b, v)
+end
 
 ## Operations
 for mulcoeff in [:mul_coefficients, :mul_coefficients!]
     @eval begin
         function $mulcoeff(A::Operator, b)
             n = size(b, 1)
-            ret = n > 0 ? oftype(b, $mulcoeff(view(A, FiniteRange, 1:n), b)) : b
+            mulcoeff_maybeconvert($mulcoeff, A, b, n)
         end
 
         function $mulcoeff(A::TimesOperator, b)

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -692,7 +692,7 @@ end
 
 
 function _mulcoeff_maybeconvert(f::F, A, b, n) where {F}
-    n > 0 ? f(view(A, FiniteRange, 1:n)) : b
+    n > 0 ? f(view(A, FiniteRange, 1:n), b) : b
 end
 function mulcoeff_maybeconvert(f, A, b, n)
     _mulcoeff_maybeconvert(f, A, b, n)


### PR DESCRIPTION
This makes the following type-inferred:
```julia
julia> @inferred (Derivative() ⊗ I) * Fun((x,y) ->x*y, Chebyshev()^2)
Fun(Ultraspherical(1) ⊗ Chebyshev(), [-2.05209e-17, 1.0, 0.0])
```