### PR TITLE
Fix spaces in DefiniteIntegral

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.28"
+version = "0.8.29"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
After this,
```julia
julia> DefiniteIntegral() * Fun(x->x^2, NormalizedChebyshev())
0.6666666666666665 anywhere
```
matches
```julia
julia> DefiniteIntegral() * Fun(x->x^2, Chebyshev())
0.6666666666666667 anywhere
```