### PR TITLE
Wrap matrix in `show` for `Operator`s

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -98,18 +98,12 @@ end
 
 function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); header::Bool=true)
     header && summary(io, B)
-    dsp = domainspace(B)
-
-    sz1_B, sz2_B = size(B)
-
-    iocompact = haskey(io, :compact) ? io : IOContext(io, :compact => true)
 
     if !isambiguous(domainspace(B)) && eltype(B) <: Number
         println(io)
-        sz1 = min(size(B,1),10)::Int
-        sz2 = min(size(B,2),10)::Int
+        sz1, sz2 = min.(size(B), 10)
         C = CharLinedMatrix(B[1:sz1, 1:sz2], isinf.(size(B)), isbanded(B))
-        print_array(iocompact, C)
+        print_array(io, C)
     end
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -51,6 +51,7 @@ end
 Base.size(A::CharLinedMatrix) = size(A.arr) .+ A.sz
 
 function Base.getindex(C::CharLinedMatrix, k::Int, j::Int)
+    @boundscheck checkbounds(C, k, j)
     BM = C.arr
     if j in axes(BM,2) && k in axes(BM,1)
         return C.arr[k,j]

--- a/src/show.jl
+++ b/src/show.jl
@@ -47,6 +47,7 @@ show(io::IO, B::Operator; kw...) = summary(io, B)
 struct CharLinedMatrix{T,A<:AbstractMatrix{T}} <: AbstractMatrix{Union{T,PrintShow}}
     arr :: A
     sz :: NTuple{2,Bool}
+    isbanded :: Bool
 end
 Base.size(A::CharLinedMatrix) = size(A.arr) .+ A.sz
 
@@ -57,7 +58,7 @@ function Base.getindex(C::CharLinedMatrix, k::Int, j::Int)
         return C.arr[k,j]
     end
     sz1, sz2 = size(C)
-    if isbanded(BM) && all(C.sz)
+    if C.isbanded && all(C.sz)
         bw1, bw2 = bandwidths(BM)
         if k in max(1,sz1-bw2):sz1+min(0,bw1) && j == sz2
             PrintShow('⋱')
@@ -107,7 +108,7 @@ function show(io::IO, mimetype::MIME"text/plain", @nospecialize(B::Operator); he
         println(io)
         sz1 = min(size(B,1),10)::Int
         sz2 = min(size(B,2),10)::Int
-        C = CharLinedMatrix(B[1:sz1, 1:sz2], isinf.(size(B)))
+        C = CharLinedMatrix(B[1:sz1, 1:sz2], isinf.(size(B)), isbanded(B))
         print_array(iocompact, C)
     end
 end


### PR DESCRIPTION
This preserves the structured display style of the parent. After this
```julia
julia> Derivative(Chebyshev()) ⊗ Derivative(Chebyshev())
KroneckerOperator : Chebyshev() ⊗ Chebyshev() → Ultraspherical(1) ⊗ Ultraspherical(1)
  ⋅    ⋅    ⋅   0.0  1.0  0.0  0.0  0.0  0.0  0.0  ⋯
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  2.0  0.0  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.0  0.0  2.0  0.0  ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
  ⋮    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱   ⋱
```
The structural zeros are preserved in the displayed form