### PR TITLE
BandedMatrix for view of ConstantOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.30"
+version = "0.8.31"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/ConstantOperator.jl
+++ b/src/Operators/banded/ConstantOperator.jl
@@ -33,6 +33,15 @@ subblockbandwidths(::ConstantOperator) = 0,0
 getindex(C::ConstantOperator,k::Integer,j::Integer) =
     k==j ? eltype(C)(C.λ) : zero(eltype(C))
 
+function BandedMatrix(S::SubOperator{T, <:ConstantOperator{T}}) where {T}
+    # only one band will be populated
+    bw = bandwidth(S,2)
+    C = parent(S)
+    n = convert(Number, C)
+    B = BandedMatrix{T}(undef, size(S), bandwidths(S))
+    B[band(bw)] .= n
+    B
+end
 
 ==(C1::ConstantOperator, C2::ConstantOperator) = C1.λ==C2.λ
 

--- a/src/Operators/banded/ConstantOperator.jl
+++ b/src/Operators/banded/ConstantOperator.jl
@@ -33,7 +33,7 @@ subblockbandwidths(::ConstantOperator) = 0,0
 getindex(C::ConstantOperator,k::Integer,j::Integer) =
     k==j ? eltype(C)(C.λ) : zero(eltype(C))
 
-function BandedMatrix(S::SubOperator{T, <:ConstantOperator{T}}) where {T}
+function BandedMatrix(S::SubOperator{T, <:ConstantOperator{T}, NTuple{2,UnitRange{Int}}}) where {T}
     # only one band will be populated
     bw = bandwidth(S,2)
     C = parent(S)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -425,6 +425,20 @@ end
         ApproxFunBase.mul_coefficients!(Operator(2I), v)
         @test v ≈ Float64[2i^2 for i in 1:4]
     end
+    @testset "ConstantOperator" begin
+        C = ConstantOperator(3.0, PointSpace(1:4))
+        @test isdiag(C)
+        @testset "BandedMatrix" begin
+            B = C[2:4, 1:3]
+            @test B == ApproxFunBase.default_BandedMatrix(view(C, 2:4, 1:3))
+
+            B = C[1:4, 1:4]
+            @test B == ApproxFunBase.default_BandedMatrix(view(C, 1:4, 1:4))
+
+            B = C[4:4, 4:4]
+            @test B == ApproxFunBase.default_BandedMatrix(view(C, 4:4, 4:4))
+        end
+    end
     @testset "Matrix types" begin
         F = Multiplication(Fun(PointSpace(1:3)), PointSpace(1:3))
         function test_matrices(F)


### PR DESCRIPTION
This provides a performance boost, and will be much faster once `BandedMatrices` is patched.
```julia
julia> Cop = Operator(1.0I) : Chebyshev();

julia> @btime $Cop[1:100, 1:100];
  554.956 ns (2 allocations: 944 bytes) # PR
  620.203 ns (2 allocations: 944 bytes) # master
```