### PR TITLE
Infinite default bandwidth for PartialInverseOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.31"
+version = "0.8.32"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/general/PartialInverseOperator.jl
+++ b/src/Operators/general/PartialInverseOperator.jl
@@ -1,37 +1,37 @@
 export PartialInverseOperator
 
 """
-    PartialInverseOperator(O::Operator, bandwidths = bandwidths(O))
+    PartialInverseOperator(O::Operator, bandwidths = (0,ℵ₀))
 
 Return an approximate estimate for `inv(O)`, such that `PartialInverseOperator(O) * O` is banded, and
 is approximately `I` up to a bandwidth that is one less than the sum of the bandwidths
 of `O` and `PartialInverseOperator(O)`.
 
 !!! note
-    Only upper triangular operators are supported as of now.
+    Only upper-triangular operators are supported as of now.
 
 # Examples
 
 ```jldoctest
 julia> C = Conversion(Chebyshev(), Ultraspherical(1));
 
-julia> P = PartialInverseOperator(C); # default bandwidth = (0,2)
+julia> P = PartialInverseOperator(C); # default bandwidth
 
 julia> P * C
 TimesOperator : Chebyshev() → Chebyshev()
- 1.0  0.0  0.0  0.0  -0.5    ⋅     ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅   1.0  0.0  0.0   0.0  -1.0    ⋅     ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅   1.0  0.0   0.0   0.0  -1.0    ⋅     ⋅     ⋅   ⋅
-  ⋅    ⋅    ⋅   1.0   0.0   0.0   0.0  -1.0    ⋅     ⋅   ⋅
-  ⋅    ⋅    ⋅    ⋅    1.0   0.0   0.0   0.0  -1.0    ⋅   ⋅
-  ⋅    ⋅    ⋅    ⋅     ⋅    1.0   0.0   0.0   0.0  -1.0  ⋅
-  ⋅    ⋅    ⋅    ⋅     ⋅     ⋅    1.0   0.0   0.0   0.0  ⋱
-  ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅    1.0   0.0   0.0  ⋱
-  ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅    1.0   0.0  ⋱
-  ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅    1.0  ⋱
-  ⋅    ⋅    ⋅    ⋅     ⋅     ⋅     ⋅     ⋅     ⋅     ⋅   ⋱
+ 1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋯
+  ⋅   1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋱
+  ⋅    ⋅   1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋱
+  ⋅    ⋅    ⋅   1.0  0.0  0.0  0.0  0.0  0.0  0.0  ⋱
+  ⋅    ⋅    ⋅    ⋅   1.0  0.0  0.0  0.0  0.0  0.0  ⋱
+  ⋅    ⋅    ⋅    ⋅    ⋅   1.0  0.0  0.0  0.0  0.0  ⋱
+  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  0.0  0.0  0.0  ⋱
+  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  0.0  0.0  ⋱
+  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  0.0  ⋱
+  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  ⋱
+  ⋮    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱    ⋱   ⋱
 
-julia> P = PartialInverseOperator(C, (0, 4)); # increase the upper bandwidth
+julia> P = PartialInverseOperator(C, (0, 4)); # specify an upper bandwidth
 
 julia> P * C
 TimesOperator : Chebyshev() → Chebyshev()
@@ -58,7 +58,7 @@ function PartialInverseOperator(CO::CachedOperator{T},bandwidths) where T<:Numbe
     return PartialInverseOperator{T,typeof(CO),typeof(bandwidths)}(CO,bandwidths)
 end
 
-function PartialInverseOperator(B::Operator, bandwidths = bandwidths(B))
+function PartialInverseOperator(B::Operator, bandwidths = (0,ℵ₀))
     PartialInverseOperator(cache(B), bandwidths)
 end
 

--- a/src/Operators/general/PartialInverseOperator.jl
+++ b/src/Operators/general/PartialInverseOperator.jl
@@ -1,7 +1,7 @@
 export PartialInverseOperator
 
 """
-    PartialInverseOperator(O::Operator, bandwidths = (0,ℵ₀))
+    PartialInverseOperator(O::Operator, bandwidths = (0, Infinities.ℵ₀))
 
 Return an approximate estimate for `inv(O)`, such that `PartialInverseOperator(O) * O` is banded, and
 is approximately `I` up to a bandwidth that is one less than the sum of the bandwidths


### PR DESCRIPTION
This would help with
```julia
julia> C = Conversion(Chebyshev(), Ultraspherical(1));

julia> P = PartialInverseOperator(C);

julia> P * Fun(x->x^3, Ultraspherical(1))
Fun(Chebyshev(), [0.0, 0.75, 0.0, 0.25])

julia> P * Fun(x->x^3, Ultraspherical(1)) ≈ Fun(x->x^3, Chebyshev())
true
```
This is mildly breaking, as the bandwidth was defined to be finite, however the default value was not anything special, and was unlikely to be useful in real cases where one would have needed to specify the bandwidth anyway. The current choice is more useful 