### PR TITLE
chop! no longer produces empty coefficients

### DIFF
--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -486,6 +486,7 @@ pad(f::Fun,n::Integer) = Fun(f.space,pad(f.coefficients,n))
 
 function chop!(sp::UnivariateSpace,cfs,tol::Real)
     n=standardchoplength(cfs,tol)
+    n=max(1,n) # empty coeffs vector causes all sorts of problems
     resize!(cfs,n)
     cfs
 end


### PR DESCRIPTION
Test case:
    using ApproxFun
    x,y = Fun(identity, Chebyshev() * Chebyshev())
    ApproxFun.norm(0*x)
    ApproxFun.norm(zero(x))

I didn't create a unit test because I couldn't find a way to reproduce with ApproxFunBase only.