### PR TITLE
three-term multiplication involving conversions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.33"
+version = "0.8.34"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -424,6 +424,11 @@ end
         @test g ≈ f
         ApproxFunBase.mul_coefficients!(Operator(2I), v)
         @test v ≈ Float64[2i^2 for i in 1:4]
+
+        C = Conversion(PointSpace(1:4), PointSpace(1:4))
+        M = Multiplication(Fun(PointSpace(1:4)), PointSpace(1:4))
+        M2 = @inferred C * M * C
+        @test M2 * f ≈ M * f
     end
     @testset "ConstantOperator" begin
         C = ConstantOperator(3.0, PointSpace(1:4))


### PR DESCRIPTION
These often show up in operations in normalized polynomial spaces, so it's worth improving the type-inference here.
```julia
julia> @inferred Multiplication(Fun(), NormalizedChebyshev())
MultiplicationWrapper : NormalizedChebyshev() → NormalizedChebyshev()
 0.0       0.707107   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
 0.707107  0.0       0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅        0.5       0.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅         ⋅        0.5  0.0  0.5   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅         ⋅         ⋅   0.5  0.0  0.5   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅         ⋅         ⋅    ⋅   0.5  0.0  0.5   ⋅    ⋅    ⋅   ⋅
  ⋅         ⋅         ⋅    ⋅    ⋅   0.5  0.0  0.5   ⋅    ⋅   ⋅
  ⋅         ⋅         ⋅    ⋅    ⋅    ⋅   0.5  0.0  0.5   ⋅   ⋅
  ⋅         ⋅         ⋅    ⋅    ⋅    ⋅    ⋅   0.5  0.0  0.5  ⋅
  ⋅         ⋅         ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   0.5  0.0  ⋱
  ⋅         ⋅         ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋱   ⋱
```