### PR TITLE
Improve type-inference in `TimesOperator * Fun`

### DIFF
--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -700,8 +700,10 @@ for mulcoeff in [:mul_coefficients, :mul_coefficients!]
 
         function $mulcoeff(A::TimesOperator, b, args...)
             ret = b
+            # we call mulcoeff_maybeconvert to improve type-inference
+            # in case b is a Vector
             for k = length(A.ops):-1:1
-                ret = $mulcoeff(A.ops[k], ret, args...)
+                ret = mulcoeff_maybeconvert($mulcoeff, A.ops[k], ret, args...)
             end
 
             ret
@@ -719,7 +721,7 @@ mulcoeff_maybeconvert(args...) = _mulcoeff_maybeconvert(args...)
 function mulcoeff_maybeconvert(f::typeof(mul_coefficients), A, b::Vector)
     v = _mulcoeff_maybeconvert(f, A, b)
     T = promote_type(eltype(A), eltype(b))
-    convert(Vector{T}, v)
+    strictconvert(Vector{T}, v)
 end
 
 function *(A::Operator, b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -475,6 +475,13 @@ end
         S = ApproxFunBase.SpaceOperator(M, sp, sp)
         @test size(S) == (3,3)
     end
+    @testset "mul_coefficients" begin
+        C = Conversion(PointSpace(1:4), PointSpace(1:4))
+        M = Multiplication(Fun(PointSpace(1:4)), PointSpace(1:4))
+        T = C * M * C
+        v = @inferred mul_coefficients(T, Float64[1:4;])
+        @test v == Float64[1:4;].^2
+    end
 end
 
 @testset "RowVector" begin


### PR DESCRIPTION
After this,
```julia
julia> S = NormalizedUltraspherical(NormalizedLegendre())
NormalizedUltraspherical(1/2)

julia> r = Fun(S)
Fun(NormalizedUltraspherical(1/2), [0.0, 0.816497])

julia> @inferred (r -> r^2)(r)
Fun(NormalizedUltraspherical(1/2), [0.471405, 0.0, 0.421637])
```