### PR TITLE
Fix mul_coefficients for wrapper types

### DIFF
--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -565,9 +565,9 @@ macro wrappergetindex(Wrap, forwardsize = true)
 
         ApproxFunBase.mul_coefficients(A::$Wrap,b) = ApproxFunBase.mul_coefficients(A.op,b)
         ApproxFunBase.mul_coefficients(A::ApproxFunBase.SubOperator{T,OP,NTuple{2,UnitRange{Int}}},b) where {T,OP<:$Wrap} =
-            ApproxFunBase.mul_coefficients(view(parent(A).op,S.indexes[1],S.indexes[2]),b)
+            ApproxFunBase.mul_coefficients(view(parent(A).op,A.indexes[1],A.indexes[2]),b)
         ApproxFunBase.mul_coefficients(A::ApproxFunBase.SubOperator{T,OP},b) where {T,OP<:$Wrap} =
-            ApproxFunBase.mul_coefficients(view(parent(A).op,S.indexes[1],S.indexes[2]),b)
+            ApproxFunBase.mul_coefficients(view(parent(A).op,A.indexes[1],A.indexes[2]),b)
 
         LinearAlgebra.isdiag(W::$Wrap) = isdiag(W.op)
 

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -189,6 +189,8 @@ end
 view(V::SubOperator, kr, jr) = view(V.parent,reindex(V,parentindices(V),(kr,jr))...)
 view(V::SubOperator,kr::InfRanges,jr::InfRanges) = view(V.parent,reindex(V,parentindices(V),(kr,jr))...)
 
+view(A::SubOperator,::Colon,jr) = view(A,1:size(A,1),jr)
+
 bandwidths(S::SubOperator) = S.bandwidths
 function colstop(S::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}},j::Integer)
     cs = colstop(parent(S),parentindices(S)[2][j])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,18 +373,20 @@ end
             f = Fun(PointSpace(1:10))
             M = Multiplication(f, space(f))
             T = TimesOperator([M,M])
-            S = view(T, 1:2:7, 1:2:7)
-            B = BandedMatrix(S)
-            for I in CartesianIndices(B)
-                @test B[I] ≈ S[Tuple(I)...]
+            for S in (view(T, 1:2:7, 1:2:7), view(M, :, 1:3), view(M, 1:3, :))
+                B = BandedMatrix(S)
+                for I in CartesianIndices(B)
+                    @test B[I] ≈ S[Tuple(I)...]
+                end
             end
         end
         @testset "mul_coefficients" begin
             sp1 = PointSpace(1:3)
             sp2 = PointSpace(2:4)
             S = ApproxFunBase.SpaceOperator(Conversion(sp1, sp1), sp2, sp2)
-            @test mul_coefficients(view(S, 1:3, 1:3), [1.0, 1.0, 1.0]) == [1.0, 1.0]
-            @test mul_coefficients(view(S, Block(1), Block(1)), [1.0, 1.0, 1.0]) == [1.0, 1.0]
+            v = [1.0, 2.0, 2.0]
+            @test mul_coefficients(view(S, axes(S)...), v) == v
+            @test mul_coefficients(view(S, Block(1), Block(1)), v) == v
         end
     end
     @testset "conversion to a matrix" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -379,6 +379,13 @@ end
                 @test B[I] ≈ S[Tuple(I)...]
             end
         end
+        @testset "mul_coefficients" begin
+            sp1 = PointSpace(1:3)
+            sp2 = PointSpace(2:4)
+            S = ApproxFunBase.SpaceOperator(Conversion(sp1, sp1), sp2, sp2)
+            @test mul_coefficients(view(S, 1:3, 1:3), [1.0, 1.0, 1.0]) == [1.0, 1.0]
+            @test mul_coefficients(view(S, Block(1), Block(1)), [1.0, 1.0, 1.0]) == [1.0, 1.0]
+        end
     end
     @testset "conversion to a matrix" begin
         M = Multiplication(Fun(identity, PointSpace(1:3)))


### PR DESCRIPTION
After this,
```julia
julia> mul_coefficients(view(Conversion(Chebyshev(), Legendre()), 1:3, 1:2), Float64[1,2])
3-element Vector{Float64}:
 1.0
 1.9999999999999998
 0.0
```