### PR TITLE
traits in size/bandwidths in wrapperstructure

### DIFF
--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -96,6 +96,8 @@ import DomainSets: dimension
 
 import IntervalSets: (..), endpoints
 
+using SimpleTraits
+
 const Vec{d,T} = SVector{d,T}
 
 export pad!, pad, chop!, sample,

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -19,7 +19,7 @@ using AbstractFFTs: Plan
 
 import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !,
               !=, eltype, iterate, /, ^, \,
-              transpose, size, tail, broadcast, broadcast!, copyto!, copy,
+              transpose, size, ndims, tail, broadcast, broadcast!, copyto!, copy,
               to_index, (:), similar, map, vcat, hcat, hvcat, show, summary,
               stride, sum, cumsum, imag, conj, inv, complex, reverse, exp,
               sqrt, abs, abs2, sign, issubset, in, first, last, rand, intersect,

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -35,22 +35,6 @@ copy(A::Operator) = A
 BroadcastStyle(::Type{<:Operator}) = DefaultArrayStyle{2}()
 broadcastable(A::Operator) = A
 
-## We assume operators are T->T
-"""
-    rangespace(op::Operator)
-
-Return the range space of `op`.  That is, `op*f` will return a `Fun` in the
-space `rangespace(op)`, provided `f` can be converted to a `Fun` in
-`domainspace(op)`.
-"""
-rangespace(A::Operator) = error("Override rangespace for $(typeof(A))")
-"""
-    domainspace(op::Operator)
-
-Return the domain space of `op`.  That is, `op*f` will first convert `f` to
-a `Fun` in the space `domainspace(op)` before applying the operator.
-"""
-domainspace(A::Operator) = error("Override domainspace for $(typeof(A))")
 spaces(A::Operator) = (rangespace(A), domainspace(A)) # order is consistent with size(::Matrix)
 domain(A::Operator) = domain(domainspace(A))
 
@@ -72,12 +56,202 @@ hasconstblocks(A::Operator) = hasconstblocks(domainspace(A)) && hasconstblocks(r
                                 getindex_value(blocklengths(domainspace(A))) == getindex_value(blocklengths(rangespace(A)))
 
 
+# Operator traits
+
+abstract type OperatorStyle end
+
+struct DefaultStyle <: OperatorStyle end
+
+struct OperatorWrapperStyle{Structure,Indexing,Spaces} <: OperatorStyle end
+const WrapperStructure = OperatorWrapperStyle{true}
+const WrapperIndexing = OperatorWrapperStyle{<:Any,true}
+const WrapperSpaces = OperatorWrapperStyle{<:Any,<:Any,true}
+const WrapperStructureIndexing = OperatorWrapperStyle{true,true}
+const WrapperStructureIndexingSpaces = OperatorWrapperStyle{true,true,true}
+
+OperatorWrapperStyle(A::Operator) = OperatorWrapperStyle(typeof(A))
+function OperatorWrapperStyle(::Type{T}) where {T<:Operator}
+    Structure = iswrapperstructure(T)
+    Indexing = iswrapperindexing(T)
+    Spaces = iswrapperspaces(T)
+    OperatorWrapperStyle{Structure,Indexing,Spaces}()
+end
+
+for f in [:iswrapperstructure, :iswrapperindexing, :iswrapperspaces]
+    @eval $f(@nospecialize(_)) = false
+end
+
+iswrapper(A) = iswrapperstructure(A) || iswrapperindexing(A) || iswrapperspaces(A)
+
+struct Functional <: OperatorStyle end
+
+isafunctional(@nospecialize(_)) = false
+
+# This disambiguates cases where an operator is both a functional and a wrapper
+# In such cases, functions get to choose which trait to dispatch on
+# All such operators must disambiguate between conflicting styles
+struct StyleConflict{W, F} <: OperatorStyle
+    wrapper :: W
+    functional :: F
+end
+
+function dominantstyle(S::StyleConflict, f, op::Operator)
+    throw(ArgumentError("please disambiguate operator style for $f and $(typeof(op))"))
+end
+
+OperatorStyle(A::Operator) = OperatorStyle(typeof(A))
+function OperatorStyle(::Type{T}) where {T<:Operator}
+    Wrap = OperatorWrapperStyle(T)
+    f = Functional()
+    if iswrapper(T) && isafunctional(T)
+        StyleConflict(Wrap, f)
+    elseif iswrapper(T)
+        Wrap
+    elseif isafunctional(T)
+        f
+    else
+        DefaultStyle()
+    end
+end
+
+
+## We assume operators are T->T
+"""
+    rangespace(op::Operator)
+
+Return the range space of `op`.  That is, `op*f` will return a `Fun` in the
+space `rangespace(op)`, provided `f` can be converted to a `Fun` in
+`domainspace(op)`.
+"""
+rangespace(A::Operator) = oprangespace(OperatorStyle(A), A)
+
+"""
+    domainspace(op::Operator)
+
+Return the domain space of `op`.  That is, `op*f` will first convert `f` to
+a `Fun` in the space `domainspace(op)` before applying the operator.
+"""
+domainspace(A::Operator) = opdomainspace(OperatorStyle(A), A)
+
+# Fallback definitions
+opbandwidths(::OperatorStyle, A) = (size(A,1)-1,size(A,2)-1)
+
+opstride(::OperatorStyle, A) = isdiag(A) ? factorial(10) : 1
+
+opisblockbanded(::OperatorStyle, A) = all(isfinite, blockbandwidths(A))::Bool
+
+opisbandedblockbanded(::OperatorStyle, A) =
+    isbandedblockbandedabove(A) && isbandedblockbandedbelow(A)
+
+opisbanded(::OperatorStyle, A) =
+    all(isfinite, bandwidths(A))::Bool
+
+function opisraggedbelow(::OperatorStyle, A)
+    isbandedbelow(A)::Bool ||
+        isbandedblockbanded(A)::Bool ||
+        isblockbandedbelow(A)::Bool
+end
+
+# this should be determinable at compile time
+#TODO: I think it can be generalized to the case when the domainspace
+# blocklengths == rangespace blocklengths, in which case replace the definition
+# of p with maximum(blocklength(domainspace(A)))
+function opblockbandwidths(::OperatorStyle, A)
+    hastrivialblocks(A) && return bandwidths(A)
+
+    if hasconstblocks(A)
+        a,b = bandwidths(A)
+        p = getindex_value(blocklengths(domainspace(A)))
+        return (-fld(-a,p),-fld(-b,p))
+    end
+
+    #TODO: Generalize to finite dimensional
+    if size(A,2) == 1
+        rs = rangespace(A)
+
+        if hasconstblocks(rs)
+            a = bandwidth(A,1)
+            p = getindex_value(blocklengths(rs))
+            return (-fld(-a,p),0)
+        end
+    end
+
+    return (length(blocklengths(rangespace(A)))-1,length(blocklengths(domainspace(A)))-1)
+end
+
+opsubblockbandwidths(::OperatorStyle, A) =
+    maximum(blocklengths(rangespace(A)))-1, maximum(blocklengths(domainspace(A)))-1
+
+opbandwidth(::OperatorStyle, A, k) = bandwidths(A)[k]
+opblockbandwidth(::OperatorStyle, A, k) = blockbandwidths(A)[k]
+opsubblockbandwidth(::OperatorStyle, A, k) = subblockbandwidths(A)[k]
+
+opsize(::OperatorStyle, A, k) = k==1 ? dimension(rangespace(A)) : dimension(domainspace(A))
+
+opisdiag(::OperatorStyle, A) = bandwidths(A)==(0,0)
+opissymmetric(::OperatorStyle, A) = false
+
+for f in [:domainspace, :rangespace]
+    opf = Symbol(:op, f)
+    @eval begin
+        $opf(::OperatorStyle, A) = error("Override domainspace for $(typeof(A))")
+        $opf(S::StyleConflict, A) = $opf(dominantstyle(S, $f, A), A)
+    end
+end
+# Since Functional doesn't change the domain space, we may forward it for WrapperSpaces
+opdomainspace(S::StyleConflict{<:WrapperSpaces}, A) = opdomainspace(S.wrapper, A)
+
+for f in [:bandwidths]
+    opf = Symbol(:op, f)
+    @eval begin
+        # we are always banded by the size
+        """
+            bandwidths(op::Operator)
+
+        Return the bandwidth of `op` in the form `(l,u)`, where `l ≥ 0` represents
+        the number of subdiagonals and `u ≥ 0` represents the number of superdiagonals.
+        """
+        $f(A::Operator) = $opf(OperatorStyle(A), A)
+        $opf(::WrapperStructure, A) = $f(A.op)
+        $opf(S::StyleConflict, A) = $opf(dominantstyle(S, $f, A), A)
+    end
+end
+
+## stride(::Operator)
+# lets us know if operators decouple the entries
+# to split into sub problems
+# A diagonal operator has essentially infinite stride
+# which we represent by a factorial, so that
+# the gcd with any number < 10 is the number
+
+for f in [:stride, :blockbandwidths, :subblockbandwidths,
+            :israggedbelow, :isbanded, :isblockbanded, :isbandedblockbanded,
+            :issymmetric, :isdiag]
+    opf = Symbol(:op, f)
+    @eval begin
+        $f(A::Operator) = $opf(OperatorStyle(A), A)
+        $opf(::WrapperStructure, A) = $f(A.op)
+        $opf(S::StyleConflict, A) = $opf(dominantstyle(S, $f, A), A)
+    end
+end
+
+for f in [:size, :bandwidth, :blockbandwidth, :subblockbandwidth]
+    opf = Symbol(:op, f)
+    @eval begin
+        $f(A::Operator, k::Integer) = $opf(OperatorStyle(A), A, k)
+        $opf(::WrapperStructure, A, k) = $f(A.op, k)
+        $opf(S::StyleConflict, A, k) = $opf(dominantstyle(S, $f, A), A, k)
+    end
+end
+
+# Functional
+opsize(::Functional, A, k) = k==1 ? 1 : dimension(domainspace(A))
+oprangespace(::Functional, F) = ConstantSpace(eltype(F))
+opblockbandwidths(::Functional, A) = 0,hastrivialblocks(domainspace(A)) ? bandwidth(A,2) : ℵ₀
+
 macro functional(FF)
     quote
-        Base.size(A::$FF,k::Integer) = k==1 ? 1 : dimension(domainspace(A))
-        ApproxFunBase.rangespace(F::$FF) = ApproxFunBase.ConstantSpace(eltype(F))
-        ApproxFunBase.isafunctional(::$FF) = true
-        ApproxFunBase.blockbandwidths(A::$FF) = 0,hastrivialblocks(domainspace(A)) ? bandwidth(A,2) : ℵ₀
+        ApproxFunBase.isafunctional(::Type{<:$FF}) = true
         function ApproxFunBase.defaultgetindex(f::$FF,k::Integer,j::Integer)
             @assert k==1
             f[j]::eltype(f)
@@ -113,9 +287,6 @@ blocksize(A::Operator) = (blocksize(A,1),blocksize(A,2))
 size(A::Operator) = (size(A,1),size(A,2))
 length(A::Operator) = size(A,1) * size(A,2)
 
-size(A::Operator,k::Integer) = opsize(A, k)
-
-
 # used to compute "end" for last index
 function lastindex(A::Operator, n::Integer)
     if n > 2
@@ -130,7 +301,7 @@ function lastindex(A::Operator, n::Integer)
 end
 lastindex(A::Operator) = size(A,1)*size(A,2)
 
-Base.ndims(::Operator) = 2
+ndims(::Operator) = 2
 
 
 
@@ -140,56 +311,17 @@ Base.ndims(::Operator) = 2
 ## bandrange and indexrange
 isbandedbelow(A::Operator) = isfinite(bandwidth(A,1))::Bool
 isbandedabove(A::Operator) = isfinite(bandwidth(A,2))::Bool
-isbanded(A::Operator) = opisbanded(A)
-
 
 isbandedblockbandedbelow(_) = false
 isbandedblockbandedabove(_) = false
 
-isbandedblockbanded(A::Operator) = opisbandedblockbanded(A::Operator)
-
-
-blockbandwidths(A::Operator) = opblockbandwidths(A::Operator)
-
-# assume dense blocks
-subblockbandwidths(K::Operator) = opsubblockbandwidths(K::Operator)
-
 isblockbandedbelow(A::Operator) = isfinite(blockbandwidth(A,1))::Bool
 isblockbandedabove(A::Operator) = isfinite(blockbandwidth(A,2))::Bool
-isblockbanded(A::Operator) = opisblockbanded(A::Operator)
-
-israggedbelow(A::Operator) = opisraggedbelow(A)
 
 
-blockbandwidth(K::Operator, k::Integer) = blockbandwidths(K)[k]
-subblockbandwidth(K::Operator,k::Integer) = subblockbandwidths(K)[k]
-
-
-bandwidth(A::Operator, k::Integer) = bandwidths(A)[k]
-# we are always banded by the size
-"""
-    bandwidths(op::Operator)
-
-Return the bandwidth of `op` in the form `(l,u)`, where `l ≥ 0` represents
-the number of subdiagonals and `u ≥ 0` represents the number of superdiagonals.
-"""
-bandwidths(A::Operator) = opbandwidths(A)
-
-
-## Strides
-# lets us know if operators decouple the entries
-# to split into sub problems
-# A diagonal operator has essentially infinite stride
-# which we represent by a factorial, so that
-# the gcd with any number < 10 is the number
-stride(A::Operator) = opstride(A::Operator)
-
-isdiag(A::Operator) = opisdiag(A)
 
 istriu(A::Operator) = bandwidth(A, 1) <= 0
 istril(A::Operator) = bandwidth(A, 2) <= 0
-
-issymmetric(A::Operator) = opissymmetric(A)
 
 
 ## Construct operators
@@ -204,7 +336,7 @@ include("SubOperator.jl")
 # sparse(B::Operator,n::Colon,m::AbstractRange)=sparse(BandedMatrix(B,n,m))
 # sparse(B::Operator,n::AbstractRange,m::Colon)=sparse(BandedMatrix(B,n,m))
 
-## geteindex
+## getindex
 
 
 """
@@ -461,89 +593,6 @@ end
 
 # Convenience for wrapper ops
 unwrap_axpy!(α,P,A) = axpy!(α,view(parent(P).op,P.indexes[1],P.indexes[2]),A)
-iswrapper(_) = false
-
-haswrapperstructure(@nospecialize(::Type)) = false
-haswrapperstructure(x::Operator) = haswrapperstructure(typeof(x))
-
-@traitdef HasWrapperStructure{X}
-@traitimpl HasWrapperStructure{X} <- haswrapperstructure(X)
-
-# Forward various structure query functions to the parent for wrappers
-
-@traitfn opbandwidths(A::X) where {X; !HasWrapperStructure{X}} =
-    (size(A,1)-1,size(A,2)-1)
-
-@traitfn opstride(A::X) where {X; !HasWrapperStructure{X}} =
-    isdiag(A) ? factorial(10) : 1
-
-@traitfn opisblockbanded(A::X) where {X; !HasWrapperStructure{X}} =
-    all(isfinite, blockbandwidths(A))::Bool
-
-@traitfn opisbandedblockbanded(A::X) where {X; !HasWrapperStructure{X}} =
-    isbandedblockbandedabove(A) && isbandedblockbandedbelow(A)
-
-@traitfn opisbanded(A::X) where {X; !HasWrapperStructure{X}} =
-    all(isfinite, bandwidths(A))::Bool
-
-@traitfn function opisraggedbelow(A::X) where {X; !HasWrapperStructure{X}}
-    isbandedbelow(A)::Bool ||
-        isbandedblockbanded(A)::Bool ||
-        isblockbandedbelow(A)::Bool
-end
-
-# this should be determinable at compile time
-#TODO: I think it can be generalized to the case when the domainspace
-# blocklengths == rangespace blocklengths, in which case replace the definition
-# of p with maximum(blocklength(domainspace(A)))
-@traitfn function opblockbandwidths(A::X) where {X; !HasWrapperStructure{X}}
-    hastrivialblocks(A) && return bandwidths(A)
-
-    if hasconstblocks(A)
-        a,b = bandwidths(A)
-        p = getindex_value(blocklengths(domainspace(A)))
-        return (-fld(-a,p),-fld(-b,p))
-    end
-
-    #TODO: Generalize to finite dimensional
-    if size(A,2) == 1
-        rs = rangespace(A)
-
-        if hasconstblocks(rs)
-            a = bandwidth(A,1)
-            p = getindex_value(blocklengths(rs))
-            return (-fld(-a,p),0)
-        end
-    end
-
-    return (length(blocklengths(rangespace(A)))-1,length(blocklengths(domainspace(A)))-1)
-end
-
-@traitfn opsubblockbandwidths(A::X) where {X; !HasWrapperStructure{X}} =
-    maximum(blocklengths(rangespace(A)))-1, maximum(blocklengths(domainspace(A)))-1
-
-defaultsize(A, k) = k==1 ? dimension(rangespace(A)) : dimension(domainspace(A))
-@traitfn opsize(A::X, k::Integer) where {X; !HasWrapperStructure{X}} =
-    defaultsize(A, k)
-
-@traitfn opisdiag(A::X) where {X; !HasWrapperStructure{X}} = bandwidths(A)==(0,0)
-@traitfn opissymmetric(A::X) where {X; !HasWrapperStructure{X}} = false
-
-for f in [:size, :stride, :bandwidths, :blockbandwidths, :subblockbandwidths,
-            :israggedbelow, :isbanded, :isblockbanded, :isbandedblockbanded,
-            :issymmetric, :isdiag]
-    opf = Symbol(:op, f)
-    @eval begin
-        @traitfn $opf(A::X) where {X; HasWrapperStructure{X}} = $f(A.op)
-    end
-end
-
-for f in [:size, :bandwidth, :blockbandwidth, :subblockbandwidth]
-    opf = Symbol(:op, f)
-    @eval begin
-        @traitfn $opf(A::X, k::Integer) where {X; HasWrapperStructure{X}} = $f(A.op, k)
-    end
-end
 
 # use this for wrapper operators that have the same structure but
 # not necessarily the same entries
@@ -561,7 +610,7 @@ macro wrapperstructure(Wrap)
      end
 
     ret = quote
-        ApproxFunBase.haswrapperstructure(::Type{<:$Wrap}) = true
+        ApproxFunBase.iswrapperstructure(::Type{<:$Wrap}) = true
         $(v...)
     end
 
@@ -637,6 +686,8 @@ macro wrappergetindex(Wrap)
         end
 
         ApproxFunBase.@wrapperstructure($Wrap) # structure is automatically inherited
+
+        ApproxFunBase.iswrapperindexing(::Type{<:$Wrap}) = true
     end
 
     esc(ret)
@@ -652,23 +703,21 @@ function _blockmaybebandedmatrix(S, f::T, fdef::D) where {T,D}
     end
 end
 
+isconstop(A) = opisconstop(OperatorStyle(A), A)
+opisconstop(::OperatorStyle, A) = false
+
 # use this for wrapper operators that have the same spaces but
 # not necessarily the same entries or structure
 #
+for f in [:domainspace, :rangespace, :opisconstop]
+    opf = Symbol(:op, f)
+    @eval $opf(::WrapperSpaces, A) = $f(A.op)
+end
+
 macro wrapperspaces(Wrap, forwarddomain = true, forwardrange = true)
-    fns = [:(ApproxFunBase.isconstop)]
-    if forwarddomain
-        fns = [fns; :(ApproxFunBase.domainspace)]
-    end
-    if forwardrange
-        fns = [fns; :(ApproxFunBase.rangespace)]
-    end
-    v = map(fns) do func
-        :($func(D::$Wrap) = $func(D.op))
-    end
     ret = quote
-        $(v...)
-        ApproxFunBase.domain(D::$Wrap) = domain(domainspace(D))
+        ApproxFunBase.iswrapperspaces(::Type{<:$Wrap}) = true
+        # ApproxFunBase.domain(D::$Wrap) = domain(domainspace(D))
     end
 
     esc(ret)
@@ -681,8 +730,6 @@ macro wrapper(Wrap, forwarddomain = true, forwardrange = true)
     ret = quote
         ApproxFunBase.@wrappergetindex($Wrap)
         ApproxFunBase.@wrapperspaces($Wrap, $forwarddomain, $forwardrange)
-
-        ApproxFunBase.iswrapper(::$Wrap) = true
     end
 
 

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -25,6 +25,10 @@ macro calculus_operator(Op)
             rangespace::R
         end
 
+        function ApproxFunBase.dominantstyle(S::ApproxFunBase.StyleConflict, ::Function, A::$WrappOp)
+            S.wrapper
+        end
+
         ApproxFunBase.@wrapper $WrappOp false false
         ApproxFunBase.domainspace(A::$WrappOp) = A.domainspace
         ApproxFunBase.rangespace(A::$WrappOp) = A.rangespace

--- a/src/Operators/banded/ConstantOperator.jl
+++ b/src/Operators/banded/ConstantOperator.jl
@@ -162,7 +162,6 @@ promoterangespace(Z::ZeroOperator,sp::Space) = ZeroOperator(domainspace(Z),sp)
 
 isconstop(::Union{ZeroOperator,ConstantOperator}) = true
 isconstop(S::SpaceOperator) = isconstop(S.op)
-isconstop(_) = false
 
 iszeroop(::ZeroOperator) = true
 iszeroop(A::ConstantOperator) = A.λ==0.0

--- a/src/Operators/functionals/CalculusFunctional.jl
+++ b/src/Operators/functionals/CalculusFunctional.jl
@@ -19,6 +19,14 @@ macro calculus_functional(Op)
             domainspace::S
         end
 
+        function ApproxFunBase.dominantstyle(S::ApproxFunBase.StyleConflict, ::Function, ::$WrappOp)
+            S.wrapper
+        end
+        function ApproxFunBase.dominantstyle(S::ApproxFunBase.StyleConflict,
+                ::typeof(ApproxFunBase.rangespace), ::$WrappOp)
+            S.functional
+        end
+
         ApproxFunBase.@wrapper $WrappOp false false
         ApproxFunBase.domainspace(A::$WrappOp) = A.domainspace
 

--- a/src/Operators/functionals/Evaluation.jl
+++ b/src/Operators/functionals/Evaluation.jl
@@ -109,6 +109,8 @@ end
 
 
 @wrapper EvaluationWrapper false
+dominantstyle(S::StyleConflict, ::Any, ::EvaluationWrapper) = S.wrapper
+
 EvaluationWrapper(sp::Space,x,order,func::Operator) =
     EvaluationWrapper{typeof(sp),typeof(x),typeof(func),typeof(order),eltype(func)}(sp,x,order,func)
 

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -46,7 +46,9 @@ end
 
 # Similar to wrapper, but different domain/domainspace/rangespace
 
-@wrappergetindex SpaceOperator false
+@wrappergetindex SpaceOperator
+
+size(S::SpaceOperator, k::Integer) = defaultsize(S, k)
 
 # SpaceOperator can change blocks, so we need to override this
 getindex(A::SpaceOperator,KR::BlockRange, JR::BlockRange) = defaultgetindex(A,KR,JR)

--- a/src/Operators/spacepromotion.jl
+++ b/src/Operators/spacepromotion.jl
@@ -48,7 +48,7 @@ end
 
 @wrappergetindex SpaceOperator
 
-size(S::SpaceOperator, k::Integer) = defaultsize(S, k)
+size(S::SpaceOperator, k::Integer) = opsize(DefaultStyle(), S, k)
 
 # SpaceOperator can change blocks, so we need to override this
 getindex(A::SpaceOperator,KR::BlockRange, JR::BlockRange) = defaultgetindex(A,KR,JR)


### PR DESCRIPTION
The goal is to move wrapper structures, wrapped indexing and similar properties to traits. This vastly reduces the number of methods that we need to define.