### PR TITLE
Fix indexing ConcreteEvaluation with AbstractRange

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.35"
+version = "0.8.36"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/functionals/Evaluation.jl
+++ b/src/Operators/functionals/Evaluation.jl
@@ -87,6 +87,8 @@ function getindex(D::ConcreteEvaluation,k::Integer)
     strictconvert(eltype(D), v)
 end
 
+getindex(D::ConcreteEvaluation, r::AbstractRange) = [D[j] for j in r]
+
 boundaryfn(x::typeof(rightendpoint)) = x
 boundaryfn(x::typeof(leftendpoint)) = x
 boundaryfn(x::Boundary) = isleftendpoint(x) ? leftendpoint : rightendpoint


### PR DESCRIPTION
Fixes
```julia
julia> Evaluation(JacobiWeight(0,0,Chebyshev()), 0.5)[1:4]
4-element Vector{Float64}:
  1.0
  0.5
 -0.5
 -1.0
```