### PR TITLE
Add tests for `Polynomial` spaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,22 +39,32 @@ DSP = "0.6, 0.7"
 DomainSets = "0.5, 0.6"
 DualNumbers = "0.6.2"
 FFTW = "0.3, 1"
+FastGaussQuadrature = "0.4, 0.5"
+FastTransforms = "0.12, 0.13, 0.14, 0.15.1"
 FillArrays = "0.11, 0.12, 0.13, 1"
+HalfIntegers = "1.5"
 InfiniteArrays = "0.11, 0.12"
 InfiniteLinearAlgebra = "0.5, 0.6"
 Infinities = "0.1"
 IntervalSets = "0.5, 0.6, 0.7"
 LazyArrays = "0.20, 0.21, 0.22, 1"
 LowRankApprox = "0.2, 0.3, 0.4, 0.5"
+OddEvenIntegers = "0.1.8"
 SimpleTraits = "0.9"
 SpecialFunctions = "0.10, 1.0, 2"
+Static = "0.8"
 StaticArrays = "0.12, 1.0"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
+FastTransforms = "057dd010-8810-581a-b7be-e3fc3b93f78c"
+HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 Infinities = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
+OddEvenIntegers = "8d37c425-f37a-4ca2-9b9d-a61bc06559d2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [targets]
-test = ["Aqua", "Random", "Infinities"]
+test = ["Aqua", "Random", "FastTransforms", "FastGaussQuadrature", "HalfIntegers", "Infinities", "OddEvenIntegers", "Static"]

--- a/test/AFOP/Chebyshev/Chebyshev.jl
+++ b/test/AFOP/Chebyshev/Chebyshev.jl
@@ -1,0 +1,258 @@
+
+export Chebyshev, NormalizedChebyshev
+
+"""
+`Chebyshev()` is the space spanned by the Chebyshev polynomials
+```
+    T_0(x),T_1(x),T_2(x),…
+```
+where `T_k(x) = cos(k*acos(x))`.  This is the default space
+as there exists a fast transform and general smooth functions on `[-1,1]`
+can be easily resolved.
+"""
+struct Chebyshev{D<:Domain,R} <: PolynomialSpace{D,R}
+    domain::D
+    function Chebyshev{D,R}(d) where {D,R}
+        isempty(d) && throw(ArgumentError("Domain cannot be empty"))
+        new(d)
+    end
+    Chebyshev{D,R}() where {D,R} = new(strictconvert(D, ChebyshevInterval()))
+end
+
+Chebyshev(d::Domain) = Chebyshev{typeof(d),real(prectype(d))}(d)
+Chebyshev() = Chebyshev(ChebyshevInterval())
+Chebyshev(d) = Chebyshev(Domain(d))
+const NormalizedChebyshev{D<:Domain,R} = NormalizedPolynomialSpace{Chebyshev{D, R}, D, R}
+NormalizedChebyshev() = NormalizedPolynomialSpace(Chebyshev())
+NormalizedChebyshev(d) = NormalizedPolynomialSpace(Chebyshev(d))
+
+function Base.getproperty(S::Chebyshev{<:Any,<:Any},v::Symbol)
+    if v==:b || v==:a
+        -0.5
+    else
+        getfield(S,v)
+    end
+end
+
+normalization(::Type{T}, sp::Chebyshev, k::Int) where T = T(π)/(2-FastTransforms.δ(k,0))
+
+Space(d::SegmentDomain) = Chebyshev(d)
+_norm(x) = norm(x)
+_norm(x::Real) = abs(x) # this preserves integers, whereas norm returns a float
+function Space(d::AbstractInterval)
+    a,b = endpoints(d)
+    d2 = if isinf(_norm(a)) && isinf(_norm(b))
+        Line(d)
+    elseif isinf(_norm(a)) || isinf(_norm(b))
+        Ray(d)
+    else
+        d
+    end
+    Chebyshev(d2)
+end
+
+
+setdomain(S::Chebyshev, d::Domain) = Chebyshev(d)
+
+ones(::Type{T}, S::Chebyshev) where {T<:Number} = Fun(S,fill(one(T),1))
+ones(S::Chebyshev) = Fun(S,fill(1.0,1))
+
+function first(f::Fun{<:Chebyshev})
+    n = ncoefficients(f)
+    n == 0 && return zero(cfstype(f))
+    n == 1 && return f.coefficients[1]
+    foldr(-,coefficients(f))
+end
+
+last(f::Fun{<:Chebyshev}) = reduce(+,coefficients(f))
+
+spacescompatible(a::Chebyshev,b::Chebyshev) = domainscompatible(a,b)
+hasfasttransform(::Chebyshev) = true
+supportsinplacetransform(::Chebyshev{<:Domain{T},T}) where {T<:AbstractFloat} = true
+
+
+## Transform
+
+transform(::Chebyshev,vals::AbstractVector,plan) = plan*vals
+itransform(::Chebyshev,cfs::AbstractVector,plan) = plan*cfs
+plan_transform(::Chebyshev,vals::AbstractVector) = plan_chebyshevtransform(vals)
+plan_itransform(::Chebyshev,cfs::AbstractVector) = plan_ichebyshevtransform(cfs)
+plan_transform!(::Chebyshev, vals::AbstractVector) = plan_chebyshevtransform!(vals)
+plan_itransform!(::Chebyshev, cfs::AbstractVector) = plan_ichebyshevtransform!(cfs)
+
+## Evaluation
+
+clenshaw(sp::Chebyshev, c::AbstractVector, x::AbstractArray) =
+    clenshaw(c,x,ClenshawPlan(promote_type(eltype(c),eltype(x)),sp,length(c),length(x)))
+
+clenshaw(::Chebyshev,c::AbstractVector,x) = chebyshev_clenshaw(c,x)
+
+clenshaw(c::AbstractVector,x::AbstractVector,plan::ClenshawPlan{S,V}) where {S<:Chebyshev,V}=
+    clenshaw(c,collect(x),plan)
+
+#TODO: This modifies x, which is not threadsafe
+clenshaw(c::AbstractVector,x::Vector,plan::ClenshawPlan{<:Chebyshev}) = chebyshev_clenshaw(c,x,plan)
+
+function clenshaw(c::AbstractMatrix{T},x::T,plan::ClenshawPlan{S,T}) where {S<:Chebyshev,T<:Number}
+    bk=plan.bk
+    bk1=plan.bk1
+    bk2=plan.bk2
+
+    m,n=size(c) # m is # of coefficients, n is # of funs
+
+    @inbounds for i = 1:n
+        bk1[i] = zero(T)
+        bk2[i] = zero(T)
+    end
+    x = 2x
+
+    @inbounds for k=m:-1:2
+        for j=1:n
+            ck = c[k,j]
+            bk[j] = muladd(x,bk1[j],ck - bk2[j])
+        end
+        bk2, bk1, bk = bk1, bk, bk2
+    end
+
+    x = x/2
+    @inbounds for i = 1:n
+        ce = c[1,i]
+        bk[i] = muladd(x,bk1[i],ce - bk2[i])
+    end
+
+    bk
+end
+
+function clenshaw(c::AbstractMatrix{T},x::AbstractVector{T},plan::ClenshawPlan{S,T}) where {S<:Chebyshev,T<:Number}
+    bk=plan.bk
+    bk1=plan.bk1
+    bk2=plan.bk2
+
+    m,n=size(c) # m is # of coefficients, n is # of funs
+
+    @inbounds for i = 1:n
+        x[i] = 2x[i]
+        bk1[i] = zero(T)
+        bk2[i] = zero(T)
+    end
+
+    @inbounds for k=m:-1:2
+        for j=1:n
+            ck = c[k,j]
+            bk[j] = muladd(x[j],bk1[j],ck - bk2[j])
+        end
+        bk2, bk1, bk = bk1, bk, bk2
+    end
+
+
+    @inbounds for i = 1:n
+        x[i] = x[i]/2
+        ce = c[1,i]
+        bk[i] = muladd(x[i],bk1[i],ce - bk2[i])
+    end
+
+    bk
+end
+
+# overwrite x
+
+function clenshaw!(c::AbstractVector,x::AbstractVector,plan::ClenshawPlan{S,V}) where {S<:Chebyshev,V}
+    N,n = length(c),length(x)
+
+    if isempty(c)
+        fill!(x,0)
+        return x
+    end
+
+    bk=plan.bk
+    bk1=plan.bk1
+    bk2=plan.bk2
+
+    @inbounds for i = 1:n
+        x[i] = 2x[i]
+        bk1[i] = zero(V)
+        bk2[i] = zero(V)
+    end
+
+    @inbounds for k = N:-1:2
+        ck = c[k]
+        for i = 1:n
+            bk[i] = muladd(x[i],bk1[i],ck - bk2[i])
+        end
+        bk2, bk1, bk = bk1, bk, bk2
+    end
+
+    ce = c[1]
+    @inbounds for i = 1:n
+        x[i] = x[i]/2
+        x[i] = muladd(x[i],bk1[i],ce-bk2[i])
+    end
+
+    x
+end
+
+## Calculus
+
+
+# diff T -> U, then convert U -> T
+integrate(f::Fun{Chebyshev{D,R}}) where {D<:IntervalOrSegment,R} =
+    Fun(f.space,fromcanonicalD(f,0)*ultraint!(ultraconversion(f.coefficients)))
+differentiate(f::Fun{Chebyshev{D,R}}) where {D<:IntervalOrSegment,R} =
+    Fun(f.space,1/fromcanonicalD(f,0)*ultraiconversion(ultradiff(f.coefficients)))
+
+
+
+
+
+## Multivariate
+
+# determine correct parameter to have at least
+# N point
+_padua_length(N) = Int(cld(-3+sqrt(1+8N),2))
+
+function squarepoints(::Type{T}, N) where T
+    pts = paduapoints(T, _padua_length(N))
+    n = size(pts,1)
+    ret = Array{SVector{2,T}}(undef, n)
+    @inbounds for k=1:n
+        ret[k] = SVector{2,T}(pts[k,1],pts[k,2])
+    end
+    ret
+end
+
+points(S::TensorSpace{<:Tuple{<:Chebyshev{<:ChebyshevInterval},<:Chebyshev{<:ChebyshevInterval}}}, N) =
+    squarepoints(real(prectype(S)), N)
+
+function points(S::TensorSpace{<:Tuple{<:Chebyshev,<:Chebyshev}},N)
+    T = real(prectype(S))
+    pts = squarepoints(T, N)
+    pts .= fromcanonical.(Ref(domain(S)), pts)
+    pts
+end
+
+plan_transform(S::TensorSpace{<:Tuple{<:Chebyshev,<:Chebyshev}},v::AbstractVector) =
+    plan_paduatransform!(v,Val{false})
+
+transform(S::TensorSpace{<:Tuple{<:Chebyshev,<:Chebyshev}},v::AbstractVector,
+        plan=plan_transform(S,v)) = plan*copy(v)
+
+plan_itransform(S::TensorSpace{<:Tuple{<:Chebyshev,<:Chebyshev}},v::AbstractVector) =
+     plan_ipaduatransform!(eltype(v),sum(1:Int(block(S,length(v)))),Val{false})
+
+itransform(S::TensorSpace{<:Tuple{<:Chebyshev,<:Chebyshev}},v::AbstractVector,
+         plan=plan_itransform(S,v)) = plan*pad(v,sum(1:Int(block(S,length(v)))))
+
+
+#TODO: adaptive
+for op in (:(Base.sin),:(Base.cos))
+    @eval ($op)(f::ProductFun{<:Chebyshev,<:Chebyshev}) =
+        ProductFun(chebyshevtransform($op.(values(f))),space(f))
+end
+
+
+
+reverseorientation(f::Fun{<:Chebyshev}) =
+    Fun(Chebyshev(reverseorientation(domain(f))),alternatesign!(copy(f.coefficients)))
+
+
+include("ChebyshevOperators.jl")

--- a/test/AFOP/Chebyshev/ChebyshevOperators.jl
+++ b/test/AFOP/Chebyshev/ChebyshevOperators.jl
@@ -1,0 +1,263 @@
+
+recA(::Type{T},::Chebyshev,k) where {T} = k == 0 ? one(T) : 2one(T)
+recB(::Type{T},::Chebyshev,_) where {T} = zero(T)
+recC(::Type{T},::Chebyshev,k) where {T} = one(T)   # one(T) ensures we get correct type
+
+recα(::Type{T},::Chebyshev,_) where {T} = zero(T)
+recβ(::Type{T},::Chebyshev,k) where {T} = ifelse(k==1,one(T),one(T)/2)   # one(T) ensures we get correct type,ifelse ensures inlining
+recγ(::Type{T},::Chebyshev,k) where {T} = one(T)/2   # one(T) ensures we get correct type
+
+
+
+
+
+## Evaluation
+
+Evaluation(S::MaybeNormalized{<:Chebyshev},x::Number,o::Integer) = ConcreteEvaluation(S,x,o)
+
+function evaluatechebyshev(n::Integer,x::T) where T<:Number
+    if n == 1
+        [one(T)]
+    else
+        p = zeros(T,n)
+        p[1] = one(T)
+        p[2] = x
+        twox = 2x
+
+        for j=2:n-1
+            p[j+1] = muladd(twox, p[j], -p[j-1])
+        end
+
+        p
+    end
+end
+
+# We assume that x is already scaled to the canonical domain. S is unused here
+function forwardrecurrence(::Type{T},S::Chebyshev,r::AbstractUnitRange{<:Integer},x::Number) where {T}
+    @assert !isempty(r) && first(r) >= 0
+    v = evaluatechebyshev(maximum(r)+1, T(x))
+    first(r) == 0 ? v : v[r .+ 1]
+end
+
+function getindex(op::ConcreteEvaluation{<:Chebyshev{<:IntervalOrSegment},<:SpecialEvalPtType}, j::Integer)
+    _getindex_eval_endpoints(op, evaluation_point(op), j)
+end
+function getindex(op::ConcreteEvaluation{<:Chebyshev{<:IntervalOrSegment},<:SpecialEvalPtType}, j::AbstractUnitRange)
+    _getindex_eval_endpoints(op, evaluation_point(op), j)
+end
+
+function _getindex_eval_endpoints(op, x, j)
+    if isleftendpoint(x)
+        _getindex_eval_leftendpoint(op, x, j)
+    else
+        _getindex_eval_rightendpoint(op, x, j)
+    end
+end
+function _getindex_eval_leftendpoint(op::ConcreteEvaluation{<:Chebyshev{<:IntervalOrSegment}}, x, j::Integer)
+    T=eltype(op)
+    if op.order == 0
+        ifelse(isodd(j),  # right rule
+            one(T),
+            -one(T))
+    else
+        #TODO: Fast version
+        op[j:j][1]
+    end
+end
+function _getindex_eval_rightendpoint(op::ConcreteEvaluation{<:Chebyshev{<:IntervalOrSegment}}, x, j::Integer)
+    T=eltype(op)
+    if op.order == 0
+        one(T)
+    else
+        #TODO: Fast version
+        op[j:j][1]
+    end
+end
+function _getindex_eval_leftendpoint(op::ConcreteEvaluation{<:Chebyshev{<:IntervalOrSegment}}, x, k::AbstractUnitRange)
+    Base.require_one_based_indexing(k)
+    T=eltype(op)
+    x = op.x
+    d = domain(op)
+    p = op.order
+    cst = strictconvert(T,(2/complexlength(d))^p)
+    n=length(k)
+
+    ret = Array{T}(undef, n)
+    for (ind, j) in enumerate(k)
+        ret[ind] = iseven(p+j) ? -1 : 1
+    end
+
+    for m in 0:p-1
+        for (ind, j) in enumerate(k)
+            ret[ind] *= (j-1)^2-m^2
+        end
+        scal!(strictconvert(T,1/(2m+1)), ret)
+    end
+
+    scal!(cst,ret)
+end
+function _getindex_eval_rightendpoint(op::ConcreteEvaluation{<:Chebyshev{<:IntervalOrSegment}}, x, k::AbstractUnitRange)
+    Base.require_one_based_indexing(k)
+    T=eltype(op)
+    x = op.x
+    d = domain(op)
+    p = op.order
+    cst = strictconvert(T,(2/complexlength(d))^p)
+    n=length(k)
+
+    ret = fill(one(T),n)
+
+    for m in 0:p-1
+        for (ind, j) in enumerate(k)
+            ret[ind] *= (j-1)^2-m^2
+        end
+        scal!(strictconvert(T,1/(2m+1)), ret)
+    end
+
+    scal!(cst,ret)
+end
+
+@inline function _Dirichlet_Chebyshev(S, order)
+    order == 0 && return ConcreteDirichlet(S,
+        ArraySpace(convert_vector_or_svector(
+            ConstantSpace.(Point.(endpoints(domain(S)))))),
+        0)
+    default_Dirichlet(S,order)
+end
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive function Dirichlet(S::Chebyshev, order)
+        _Dirichlet_Chebyshev(S, order)
+    end
+else
+    function Dirichlet(S::Chebyshev, order)
+        _Dirichlet_Chebyshev(S, order)
+    end
+end
+
+function getindex(op::ConcreteDirichlet{<:Chebyshev},
+                                             k::Integer,j::Integer)
+    if op.order == 0
+        k == 1 && iseven(j) && return -one(eltype(op))
+        return one(eltype(op))
+    else
+        error("Only zero Dirichlet conditions implemented")
+    end
+end
+
+function Matrix(S::SubOperator{T,ConcreteDirichlet{C,V,T},
+                                NTuple{2,UnitRange{Int}}}) where {C<:Chebyshev,V,T}
+    ret = Array{T}(undef, size(S)...)
+    kr,jr = parentindices(S)
+    isempty(kr) && return ret
+    isempty(jr) && return ret
+    if first(kr) == 1
+        if isodd(jr[1])
+            ret[1,1:2:end] .= one(T)
+            ret[1,2:2:end] .= -one(T)
+        else
+            ret[1,1:2:end] .= -one(T)
+            ret[1,2:2:end] .= one(T)
+        end
+    end
+    if last(kr) == 2
+        ret[end,:] .= one(T)
+    end
+    return ret
+end
+#
+
+# Multiplication
+
+Base.stride(M::ConcreteMultiplication{U,V}) where {U<:Chebyshev,V<:Chebyshev} =
+    stride(M.f)
+
+getindex(M::ConcreteMultiplication{C,C,T},k::Integer,j::Integer) where {T,C<:Chebyshev} =
+    chebmult_getindex(coefficients(M.f),k,j)
+
+getindex(M::ConcreteMultiplication{C,PS,T},k::Integer,j::Integer) where {PS<:PolynomialSpace,T,C<:Chebyshev} =
+    M[k:k,j:j][1,1]
+
+
+function BandedMatrix(S::SubOperator{T,ConcreteMultiplication{C,C,T},NTuple{2,UnitRange{Int}}}) where {C<:Chebyshev,T}
+    ret = BandedMatrix(Zeros, S)
+
+    kr,jr=parentindices(S)
+    cfs=parent(S).f.coefficients
+
+    isempty(cfs) && return ret
+
+    # Toeplitz part
+    sym_toeplitz_axpy!(1.0,0.5,cfs,kr,jr,ret)
+
+    #Hankel part
+    hankel_axpy!(0.5,cfs,kr,jr,ret)
+
+    # divide first row by half
+    if first(kr)==1
+        if first(jr)==1
+            ret[1,1]+=0.5cfs[1]
+        end
+
+        for j=1:min(1+ret.u,size(ret,2))
+            ret[1,j]/=2
+        end
+    end
+
+
+    ret
+end
+
+
+
+## Derivative
+
+function Derivative(sp::Chebyshev{DD},order::Number) where {DD<:IntervalOrSegment}
+    assert_integer(order)
+    ConcreteDerivative(sp,order)
+end
+
+
+rangespace(D::ConcreteDerivative{Chebyshev{DD,RR}}) where {DD<:IntervalOrSegment,RR} =
+    Ultraspherical(D.order,domain(D))
+
+bandwidths(D::ConcreteDerivative{Chebyshev{DD,RR}}) where {DD<:IntervalOrSegment,RR} = -D.order,D.order
+Base.stride(D::ConcreteDerivative{Chebyshev{DD,RR}}) where {DD<:IntervalOrSegment,RR} = D.order
+
+isdiag(D::ConcreteDerivative{<:Chebyshev{<:IntervalOrSegment}}) = false
+
+function getindex(D::ConcreteDerivative{Chebyshev{DD,RR},K,T},k::Integer,j::Integer) where {DD<:IntervalOrSegment,RR,K,T}
+    m=D.order
+    d=domain(D)
+
+    if j==k+m
+        C=strictconvert(T,pochhammer(one(T),m-1)/2*(4/complexlength(d))^m)
+        strictconvert(T,C*(m+k-one(T)))
+    else
+        zero(T)
+    end
+end
+
+linesum(f::Fun{Chebyshev{DD,RR}}) where {DD<:IntervalOrSegment,RR} =
+    sum(setcanonicaldomain(f))*arclength(domain(f))/2
+
+
+
+## Clenshaw-Curtis functional
+
+for (Func,Len) in ((:DefiniteIntegral,:complexlength),(:DefiniteLineIntegral,:arclength))
+    ConcFunc = Symbol(:Concrete, Func)
+    @eval begin
+        $Func(S::Chebyshev{D}) where {D<:IntervalOrSegment} = $ConcFunc(S)
+        function getindex(Σ::$ConcFunc{Chebyshev{D,R},T},k::Integer) where {D<:IntervalOrSegment,R,T}
+            d = domain(Σ)
+            C = $Len(d)/2
+
+            isodd(k) ? strictconvert(T,2C/(k*(2-k))) : zero(T)
+        end
+    end
+end
+
+
+
+ReverseOrientation(S::Chebyshev) = ReverseOrientationWrapper(NegateEven(S,reverseorientation(S)))
+Reverse(S::Chebyshev) = ReverseWrapper(NegateEven(S,S))

--- a/test/AFOP/Jacobi/Jacobi.jl
+++ b/test/AFOP/Jacobi/Jacobi.jl
@@ -1,0 +1,227 @@
+export Jacobi, NormalizedJacobi, Legendre, NormalizedLegendre
+
+"""
+`Jacobi(b,a)` represents the space spanned by Jacobi polynomials `P_k^{(a,b)}`,
+which are orthogonal with respect to the weight `(1+x)^β*(1-x)^α`
+"""
+struct Jacobi{D<:Domain,R,T} <: PolynomialSpace{D,R}
+    b::T
+    a::T
+    domain::D
+    Jacobi{D,R}(b::T,a::T,d::D) where {D,R,T<:Number} = new{D,R,T}(b,a,d)
+end
+Jacobi(b::T,a::T,d::Domain) where {T<:Number} =
+    Jacobi{typeof(d),promote_type(T,real(prectype(d)))}(b, a, d)
+Legendre(domain = ChebyshevInterval()) = Jacobi(0,0,Domain(domain)::Domain)
+Legendre(s::PolynomialSpace) = Legendre(Jacobi(s))
+Legendre(s::Jacobi) = s.a == s.b == 0 ? s : throw(ArgumentError("can't convert $s to Legendre"))
+Jacobi(b::Number,a::Number,d=ChebyshevInterval()) = Jacobi(promote(b, a)..., Domain(d)::Domain)
+function Jacobi(A::Ultraspherical)
+    m = order(A)
+    n = m + half(Odd(-1))
+    Jacobi(n,n,domain(A))
+end
+function Jacobi(A::Chebyshev)
+    n = half(Odd(-1))
+    Jacobi(n,n,domain(A))
+end
+Jacobi(A::Jacobi) = A
+
+const NormalizedJacobi{D<:Domain,R,T} = NormalizedPolynomialSpace{Jacobi{D,R,T},D,R}
+NormalizedJacobi(s...) = NormalizedPolynomialSpace(Jacobi(s...))
+NormalizedJacobi(s::Space) = NormalizedPolynomialSpace(Jacobi(_stripnorm(s)))
+NormalizedLegendre(d...) = NormalizedPolynomialSpace(Legendre(d...))
+NormalizedLegendre(s::Space) = NormalizedPolynomialSpace(Legendre(_stripnorm(s)))
+
+function normalization(::Type{T}, sp::Jacobi, k::Int) where T
+    x = FastTransforms.Anαβ(k, sp.a, sp.b)
+    if sp.a == sp.b == -0.5 && k == 0
+        # In this case, the expression for Anαβ has a division by zero, so we evaluate this using Mathematica
+        # In principle this may be generalized to arbitrary α + β = -1
+        # The exact expression from Mathematica in terms of the hypergeometric 2F1 function
+        # \fbox{$\frac{\, _2F_1(1,-\alpha ;\beta +2;-1)}{\beta +1}+\frac{\, _2F_1(1,-\beta ;\alpha +2;-1)}{\alpha +1}\text{ if }\alpha >-1\land \beta >-1$}
+        # or, by eliminating β and expressed in terms of the polygamma function,
+        # \fbox{$\frac{1}{2} \left(\psi ^{(0)}\left(\frac{1}{2}-\frac{\alpha }{2}\right)-\psi ^{(0)}\left(-\frac{\alpha }{2}\right)\right)+\frac{1}{2} \left(\psi ^{(0)}\left(\frac{\alpha }{2}+1\right)-\psi ^{(0)}\left(\frac{\alpha }{2}+\frac{1}{2}\right)\right)\text{ if }-1<\alpha <0$}
+        oftype(x, pi)
+    else
+        x
+    end
+end
+
+function Ultraspherical(J::Jacobi)
+    if J.a == J.b
+        Ultraspherical(J.a+_onehalf(J.a),domain(J))
+    else
+        error("Cannot construct Ultraspherical with a=$(J.a) and b=$(J.b)")
+    end
+end
+NormalizedUltraspherical(NS::NormalizedPolynomialSpace{<:Jacobi}) =
+    NormalizedPolynomialSpace(Ultraspherical(NS.space))
+NormalizedJacobi(NS::NormalizedPolynomialSpace{<:Union{Ultraspherical, Chebyshev}}) =
+    NormalizedPolynomialSpace(Jacobi(NS.space))
+
+Base.promote_rule(::Type{Jacobi{D,R1,T1}},::Type{Jacobi{D,R2,T2}}) where {D,R1,R2,T1,T2} =
+    Jacobi{D,promote_type(R1,R2),promote_type(T1,T2)}
+convert(::Type{Jacobi{D,R1,T1}},J::Jacobi{D,R2,T2}) where {D,R1,R2,T1,T2} =
+    Jacobi{D,R1}(T1(J.b)::T1, T1(J.a)::T1, J.domain)::Jacobi{D,R1,T1}
+
+compare_orders((Aa, Ba)::NTuple{2,Number}, (Ab, Bb)::NTuple{2,Number}) = compare_orders(Aa, Ba) && compare_orders(Ab, Bb)
+spacescompatible(a::Jacobi, b::Jacobi) = compare_orders((a.a, b.a), (a.b, b.b)) && domainscompatible(a,b)
+
+function canonicalspace(S::Jacobi)
+    if isapproxhalfoddinteger(S.a) && isapproxhalfoddinteger(S.b)
+        Chebyshev(domain(S))
+    else
+        # return space with parameters in (-1,0.]
+        Jacobi(mod(S.b,-1),mod(S.a,-1),domain(S))
+    end
+end
+
+reverseorientation(S::Jacobi) = Jacobi(S.a, S.b, reverseorientation(domain(S)))
+ReverseOrientation(S::Jacobi) = ReverseOrientationWrapper(NegateEven(S,reverseorientation(S)))
+reverseorientation(f::Fun{<:Jacobi}) =
+    Fun(reverseorientation(space(f)), alternatesign!(copy(f.coefficients)))
+
+
+#####
+# jacobirecA/B/C is from dlmf:
+# p_{n+1} = (A_n x + B_n)p_n - C_n p_{n-1}
+#####
+@inline function jacobirecA(::Type{T},α,β,k)::T where T
+    if k==0 && ((α+β==0)||(α+β==-1))
+        (α+β)/2+one(T)
+    else
+        (2k+α+β+one(T))*(2k+α+β+2one(T))/(2*(k+one(T))*(k+α+β+one(T)))
+    end
+end
+@inline function jacobirecB(::Type{T},α,β,k)::T where T
+    if k==0 && ((α+β==0)||(α+β==-1))
+        (α-β)*one(T)/2
+    else
+        (α-β)*(α+β)*(2k+α+β+one(T))/(2*(k+one(T))*(k+α+β+one(T))*(2one(T)*k+α+β))
+    end
+end
+@inline function jacobirecC(::Type{T},α,β,k)::T where T
+    (one(T)*k+α)*(one(T)*k+β)*(2k+α+β+2one(T))/((k+one(T))*(k+α+β+one(T))*(2one(T)*k+α+β))
+end
+#####
+# jacobirecA/B/C is from dlmf:
+# x p_{n-1} =γ_n p_{n-2} + α_n p_{n-1} +  p_n β_n
+#####
+
+@inline jacobirecγ(::Type{T},α,β,k) where {T} = jacobirecC(T,α,β,k-1)/jacobirecA(T,α,β,k-1)
+@inline jacobirecα(::Type{T},α,β,k) where {T} = -jacobirecB(T,α,β,k-1)/jacobirecA(T,α,β,k-1)
+@inline jacobirecβ(::Type{T},α,β,k) where {T} = 1/jacobirecA(T,α,β,k-1)
+
+for (REC,JREC) in ((:recα,:jacobirecα),(:recβ,:jacobirecβ),(:recγ,:jacobirecγ),
+                   (:recA,:jacobirecA),(:recB,:jacobirecB),(:recC,:jacobirecC))
+    @eval @inline $REC(::Type{T},sp::Jacobi,k) where {T} = $JREC(T,sp.a,sp.b,k)::T
+end
+
+
+function jacobip(::Type{T},r::AbstractRange,α,β,x::Number) where T
+    if x==1 && α==0
+        fill(one(T), length(r))
+    elseif x==-1 && β==0
+        (-one(T)).^r
+    elseif isempty(r)
+        T[]
+    else
+        n=r[end]+1
+        if n<=2
+            v=T[1,(α-β+(2+α+β)*x)/2]
+        else
+            v=Vector{T}(undef, n)  # x may be complex
+            v[1]=1
+            v[2]=(α-β+(2+α+β)*x)/2
+
+            @inbounds for k=2:n-1
+                v[k+1]=(jacobirecA(T,α,β,k-1)*x+jacobirecB(T,α,β,k-1))*v[k] - jacobirecC(T,α,β,k-1)*v[k-1]
+            end
+        end
+        v[r.+1]
+    end
+end
+
+
+jacobip(r::AbstractRange,α,β,x::Number) = jacobip(promote_type(typeof(α),typeof(β),typeof(x)),r,α,β,x)
+
+jacobip(::Type{T},n::Integer,α,β,v) where {T} = jacobip(T,n:n,α,β,v)[1]
+jacobip(n::Integer,α,β,v) = jacobip(n:n,α,β,v)[1]
+jacobip(::Type{T},n,S::Jacobi,v) where {T} = jacobip(T,n,S.a,S.b,v)
+jacobip(n,S::Jacobi,v) = jacobip(n,S.a,S.b,v)
+
+
+
+
+
+include("jacobitransform.jl")
+include("JacobiOperators.jl")
+
+
+
+
+one(::Type{T},S::Jacobi) where {T<:Number} = Fun(S,fill(one(T),1))
+one(S::Jacobi) = Fun(S,fill(one(Float64),1))
+zeros(::Type{T},S::Jacobi) where {T<:Number} = Fun(S,zeros(T,1))
+zeros(S::Jacobi) = Fun(S,zeros(prectype(S),1))
+
+_Fun(J::Jacobi, ::ChebyshevInterval) = Fun(J, [(J.b-J.a)/(2+J.a+J.b),2.0/(2+J.a+J.b)])
+_unscaledcoeff(J) = [2.0*(J.b + 1)/(2+J.a+J.b), 2.0/(2+J.a+J.b)]
+function _Fun(J::Jacobi, d::Interval)
+    scale = complexlength(d)/2
+    coeffs = _unscaledcoeff(J) .* scale
+    coeffs[1] += leftendpoint(d)
+    Fun(J, coeffs)
+end
+function _Fun(J::Jacobi, d)
+    complexlength(d)/2*(Fun(J,_unscaledcoeff(J)))+leftendpoint(d)
+end
+
+function Fun(::typeof(identity), J::Jacobi)
+    _Fun(J, domain(J))
+end
+
+
+setdomain(S::Jacobi,d::Domain)=Jacobi(S.b,S.a,d)
+
+
+# O(min(m,n)) Jacobi conjugated inner product
+
+function conjugatedinnerproduct(sp::Jacobi,u::AbstractVector{S},v::AbstractVector{V}) where {S,V}
+    T,mn = promote_type(S,V),min(length(u),length(v))
+    α,β = sp.a,sp.b
+    if mn > 1
+        wi = 2^(α+β+1)*gamma(α+1)*gamma(β+1)/gamma(α+β+2)
+        ret = u[1]*wi*v[1]
+        for i=2:mn
+            wi *= (α+i-1)*(β+i-1)/(i-1)/(i-1+α+β)*(2i+α+β-3)/(2i+α+β-1)
+            ret += u[i]*wi*v[i]
+        end
+        return ret
+    elseif mn > 0
+        wi = 2^(α+β+1)*gamma(α+1)*gamma(β+1)/gamma(α+β+2)
+        return u[1]*wi*v[1]
+    else
+        return zero(promote_type(eltype(u),eltype(v)))
+    end
+end
+
+function bilinearform(f::Fun{J},g::Fun{J}) where {J<:Jacobi}
+    @assert domain(f) == domain(g)
+    if f.space.a == g.space.a == 0. && f.space.b == g.space.b == 0.
+        return complexlength(domain(f))/2*conjugatedinnerproduct(g.space,f.coefficients,g.coefficients)
+    else
+        return defaultbilinearform(f,g)
+    end
+end
+
+
+function linebilinearform(f::Fun{J},g::Fun{J}) where {J<:Jacobi}
+    @assert domain(f) == domain(g)
+    if f.space.a == g.space.a == 0. && f.space.b == g.space.b == 0.
+        return arclength(domain(f))/2*conjugatedinnerproduct(g.space,f.coefficients,g.coefficients)
+    else
+        return defaultlinebilinearform(f,g)
+    end
+end

--- a/test/AFOP/Jacobi/JacobiOperators.jl
+++ b/test/AFOP/Jacobi/JacobiOperators.jl
@@ -1,0 +1,572 @@
+## Derivative
+
+# specialize Derivative so that this is type-inferred even without constant propagation
+Derivative(J::Jacobi) = ConcreteDerivative(J,1)
+@inline function _Derivative(J::Jacobi, k::Number)
+    assert_integer(k)
+    if k==1
+        return ConcreteDerivative(J,1)
+    else
+        d = domain(J)
+        v = [ConcreteDerivative(Jacobi(J.b+i-1, J.a+i-1, d)) for i in k:-1:1]
+        DerivativeWrapper(TimesOperator(v), k, J)
+    end
+end
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive Derivative(J::Jacobi, k::Number) =
+        _Derivative(J, k)
+else
+    Derivative(J::Jacobi, k::Number) = _Derivative(J, k)
+end
+
+
+rangespace(D::ConcreteDerivative{<:Jacobi}) = Jacobi(D.space.b+D.order,D.space.a+D.order,domain(D))
+bandwidths(D::ConcreteDerivative{<:Jacobi}) = -D.order,D.order
+isdiag(D::ConcreteDerivative{<:Jacobi}) = false
+
+getindex(T::ConcreteDerivative{<:Jacobi}, k::Integer, j::Integer) =
+    j==k+1 ? eltype(T)((k+1+T.space.a+T.space.b)/complexlength(domain(T))) : zero(eltype(T))
+
+
+# Evaluation
+
+Evaluation(S::MaybeNormalized{<:Jacobi},x::Number,o::Integer) = ConcreteEvaluation(S,x,o)
+
+ldiffbc(d::MaybeNormalized{<:Union{Chebyshev, Ultraspherical, Jacobi}},k) = Evaluation(d,LeftEndPoint,k)
+rdiffbc(d::MaybeNormalized{<:Union{Chebyshev, Ultraspherical, Jacobi}},k) = Evaluation(d,RightEndPoint,k)
+
+## Integral
+
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive Integral(J::Jacobi, k::Number) = _Integral(J, k)
+else
+    Integral(J::Jacobi, k::Number) = _Integral(J, k)
+end
+
+@inline function _Integral(J::Jacobi,k::Number)
+    assert_integer(k)
+    @assert k > 0 "order of integral must be > 0"
+    if k > 1
+        Q=Integral(J,1)
+        IntegralWrapper(TimesOperator(Integral(rangespace(Q),k-1),Q),k,J)
+    elseif J.a > 0 && J.b > 0   # we have a simple definition
+        ConcreteIntegral(J,1)
+    else   # convert and then integrate
+        abmin = min(J.a, J.b)
+        nsteps = length(abmin:0)
+        a = J.a + nsteps
+        b = J.b + nsteps
+        sp=Jacobi(b,a,domain(J))
+        C=_conversion_shiftordersbyone(J,sp)
+        Qconc=ConcreteIntegral(sp,1)
+        IntegralWrapper(TimesOperator(Qconc,C),1,J,rangespace(Qconc))
+    end
+end
+
+
+rangespace(D::ConcreteIntegral{<:Jacobi}) = Jacobi(D.space.b-D.order,D.space.a-D.order,domain(D))
+bandwidths(D::ConcreteIntegral{<:Jacobi}) = D.order,-D.order
+isdiag(D::ConcreteIntegral{<:Jacobi}) = false
+
+function getindex(T::ConcreteIntegral{<:Jacobi}, k::Integer, j::Integer)
+    @assert T.order==1
+    if k≥2 && j==k-1
+        complexlength(domain(T))./(k+T.space.a+T.space.b-2)
+    else
+        zero(eltype(T))
+    end
+end
+
+
+## Volterra Integral operator
+
+Volterra(d::IntervalOrSegment) = Volterra(Legendre(d))
+function Volterra(S::Jacobi, order::Integer)
+    @assert S.a == S.b == 0.0
+    @assert order==1
+    ConcreteVolterra(S,order)
+end
+
+rangespace(V::ConcreteVolterra{J}) where {J<:Jacobi}=Jacobi(-1.0,0.0,domain(V))
+bandwidths(::ConcreteVolterra{<:Jacobi}) = 1,0
+
+function getindex(V::ConcreteVolterra{J},k::Integer,j::Integer) where J<:Jacobi
+    d=domain(V)
+    C = complexlength(d)/2
+    if k≥2
+        if j==k-1
+            C/(k-1.5)
+        elseif j==k
+            -C/(k-0.5)
+        else
+            zero(eltype(V))
+        end
+    else
+        zero(eltype(V))
+    end
+end
+
+
+for (Func,Len,Sum) in ((:DefiniteIntegral,:complexlength,:sum),(:DefiniteLineIntegral,:arclength,:linesum))
+    ConcFunc = Symbol(:Concrete, Func)
+
+    @eval begin
+        $Func(S::Jacobi{<:IntervalOrSegment}) = $ConcFunc(S)
+
+        function getindex(Σ::$ConcFunc{<:Jacobi{<:IntervalOrSegment},T}, k::Integer) where {T}
+            dsp = domainspace(Σ)
+
+            if dsp.b == dsp.a == 0
+                # TODO: copy and paste
+                k == 1 ? strictconvert(T,$Sum(Fun(dsp,[one(T)]))) : zero(T)
+            else
+                strictconvert(T,$Sum(Fun(dsp,[zeros(T,k-1);1])))
+            end
+        end
+
+        function bandwidths(Σ::$ConcFunc{<:Jacobi{<:IntervalOrSegment}})
+            if domainspace(Σ).b == domainspace(Σ).a == 0
+                0,0  # first entry
+            else
+                0,ℵ₀
+            end
+        end
+    end
+end
+
+function _conversion_shiftordersbyone(L::Jacobi, M::Jacobi)
+    dl=domain(L)
+    dm=domain(M)
+    # We split this into steps where a and b are changed by 1:
+    # Define the intermediate space J = Jacobi(M.b, L.a, dm)
+    # Conversion(L, M) == Conversion(J, M) * Conversion(L, J)
+    # Conversion(L, J) = Conversion(Jacobi(L.b, L.a, dm), Jacobi(M.b, L.a, dm))
+    # Conversion(J, M) = Conversion(Jacobi(M.b, L.a, dm), Jacobi(M.b, M.a, dm))
+    CLJ = [ConcreteConversion(Jacobi(b-1,L.a,dm), Jacobi(b, L.a, dm)) for b in M.b:-1:L.b+1]
+    CJM = [ConcreteConversion(Jacobi(M.b,a-1,dm), Jacobi(M.b, a, dm)) for a in M.a:-1:L.a+1]
+    C = [CJM; CLJ]
+    return ConversionWrapper(TimesOperator(C))
+end
+
+## Conversion
+# We can only increment by a or b by one, so the following
+# multiplies conversion operators to handle otherwise
+
+function Conversion(L::Jacobi,M::Jacobi)
+    domain(L) == reverseorientation(domain(M)) &&
+        return ConversionWrapper(Conversion(reverseorientation(L), M)*ReverseOrientation(L))
+
+    domain(L) == domain(M) || domain(L) == reverseorientation(domain(M)) ||
+        throw(ArgumentError("Domains must be the same"))
+
+    dm=domain(M)
+    dl=domain(L)
+
+    if isapproxinteger(L.a-M.a) && isapproxinteger(L.b-M.b) && M.b >= L.b && M.a >= L.a
+        if isapprox(L.a,M.a) && isapprox(L.b,M.b)
+            return ConversionWrapper(Operator(I,L))
+        elseif (isapprox(L.b+1,M.b) && isapprox(L.a,M.a)) ||
+                (isapprox(L.b,M.b) && isapprox(L.a+1,M.a))
+            return ConcreteConversion(L,M)
+        elseif L.a ≈ L.b && isapproxminhalf(L.a) && M.a ≈ M.b
+            return Conversion(L,Chebyshev(dl),Ultraspherical(M),M)
+        elseif L.a ≈ L.b && M.a ≈ M.b && isapproxminhalf(M.a)
+            return Conversion(L,Ultraspherical(L),Chebyshev(dm),M)
+        elseif L.a ≈ L.b && M.a ≈ M.b
+            return Conversion(L,Ultraspherical(L),Ultraspherical(M),M)
+        else
+            return _conversion_shiftordersbyone(L, M)
+        end
+    elseif isapproxhalfoddinteger(L.a - M.a) && isapproxhalfoddinteger(L.b - M.b)
+        if L.a ≈ L.b && M.a ≈ M.b && isapproxminhalf(M.a)
+            return Conversion(L,Ultraspherical(L),Chebyshev(dm),M)
+        elseif L.a ≈ L.b && isapproxminhalf(L.a) && M.a ≈ M.b && M.a >= L.a
+            return Conversion(L,Chebyshev(dl),Ultraspherical(M),M)
+        elseif L.a ≈ L.b && M.a ≈ M.b && M.a >= L.a
+            return Conversion(L,Ultraspherical(L),Ultraspherical(M),M)
+        end
+    end
+
+    throw(ArgumentError("please implement $L → $M"))
+end
+
+bandwidths(::ConcreteConversion{<:Jacobi,<:Jacobi}) = (0,1)
+
+
+
+function getindex(C::ConcreteConversion{<:Jacobi,<:Jacobi,T},k::Integer,j::Integer) where {T}
+    L=C.domainspace
+    if L.b+1==C.rangespace.b
+        if j==k
+            k==1 ? strictconvert(T,1) : strictconvert(T,(L.a+L.b+k)/(L.a+L.b+2k-1))
+        elseif j==k+1
+            strictconvert(T,(L.a+k)./(L.a+L.b+2k+1))
+        else
+            zero(T)
+        end
+    elseif L.a+1==C.rangespace.a
+        if j==k
+            k==1 ? strictconvert(T,1) : strictconvert(T,(L.a+L.b+k)/(L.a+L.b+2k-1))
+        elseif j==k+1
+            strictconvert(T,-(L.b+k)./(L.a+L.b+2k+1))
+        else
+            zero(T)
+        end
+    else
+        error("Not implemented")
+    end
+end
+
+
+
+
+# return the space that has banded Conversion to the other
+function conversion_rule(A::Jacobi,B::Jacobi)
+    if isapproxinteger(A.a-B.a) && isapproxinteger(A.b-B.b)
+        Jacobi(min(A.b,B.b),min(A.a,B.a),domain(A))
+    else
+        NoSpace()
+    end
+end
+
+
+
+## Ultraspherical Conversion
+
+# Assume m is compatible
+
+function Conversion(A::PolynomialSpace, B::Jacobi)
+    @assert domain(A) == domain(B)
+    J = Jacobi(A)
+    J == B ? ConcreteConversion(A,B) :
+             ConversionWrapper(SpaceOperator(TimesOperator(Conversion(J,B),Conversion(A,J)), A, B))
+end
+
+function Conversion(A::Jacobi, B::PolynomialSpace)
+    @assert domain(A) == domain(B)
+    J = Jacobi(B)
+    J == A ? ConcreteConversion(A,B) :
+             ConversionWrapper(SpaceOperator(TimesOperator(Conversion(J,B),Conversion(A,J)), A, B))
+end
+
+function Conversion(A::Jacobi, B::Chebyshev)
+    @assert domain(A) == domain(B)
+    if isequalminhalf(A.a) && isequalminhalf(A.b)
+        ConcreteConversion(A,B)
+    elseif A.a == A.b == 0
+        ConversionWrapper(SpaceOperator(ConcreteConversion(Ultraspherical(A), B), A, B))
+    elseif A.a == A.b
+        US = Ultraspherical(A)
+        ConversionWrapper(SpaceOperator(TimesOperator(Conversion(US,B), ConcreteConversion(A,US)), A, B))
+    else
+        J = Jacobi(B)
+        ConcreteConversion(J,B)*Conversion(A,J)
+    end
+end
+
+function Conversion(A::Chebyshev, B::Jacobi)
+    @assert domain(A) == domain(B)
+    if isequalminhalf(B.a) && isequalminhalf(B.b)
+        ConcreteConversion(A,B)
+    elseif B.a == B.b == 0
+        ConversionWrapper(SpaceOperator(ConcreteConversion(A, Ultraspherical(B)), A, B))
+    elseif B.a == B.b
+        US = Ultraspherical(B)
+        ConversionWrapper(SpaceOperator(TimesOperator(ConcreteConversion(US,B), Conversion(A,US)), A, B))
+    else
+        J = Jacobi(A)
+        Conversion(J,B)*ConcreteConversion(A,J)
+    end
+end
+
+
+@inline function _Conversion(A::Jacobi, B::Ultraspherical)
+    @assert domain(A) == domain(B)
+    if isequalminhalf(A.a) && isequalminhalf(A.b)
+        C = Chebyshev(domain(A))
+        ConversionWrapper(SpaceOperator(
+            TimesOperator(Conversion(C,B), ConcreteConversion(A,C)), A, B))
+    elseif isequalminhalf(A.a - order(B)) && isequalminhalf(A.b - order(B))
+        ConcreteConversion(A,B)
+    elseif A.a == A.b == 0
+        ConversionWrapper(SpaceOperator(Conversion(Ultraspherical(A), B), A, B))
+    elseif A.a == A.b
+        US = Ultraspherical(A)
+        ConversionWrapper(SpaceOperator(
+            TimesOperator(Conversion(US,B), ConcreteConversion(A,US)), A, B))
+    else
+        J = Jacobi(B)
+        ConcreteConversion(J,B)*Conversion(A,J)
+    end
+end
+
+@inline function _Conversion(A::Ultraspherical, B::Jacobi)
+    @assert domain(A) == domain(B)
+    if isequalminhalf(B.a) && isequalminhalf(B.b)
+        C = Chebyshev(domain(B))
+        ConversionWrapper(SpaceOperator(
+            TimesOperator(ConcreteConversion(C, B), Conversion(A, C)), A, B))
+    elseif isequalminhalf(B.a - order(A)) && isequalminhalf(B.b - order(A))
+        ConcreteConversion(A,B)
+    elseif B.a == B.b == 0
+        ConversionWrapper(SpaceOperator(Conversion(A, Ultraspherical(B)), A, B))
+    elseif B.a == B.b
+        US = Ultraspherical(B)
+        ConversionWrapper(SpaceOperator(
+            TimesOperator(ConcreteConversion(US,B), Conversion(A,US)), A, B))
+    else
+        J = Jacobi(A)
+        Conversion(J,B)*ConcreteConversion(A,J)
+    end
+end
+
+@static if VERSION >= v"1.8"
+    Base.@constprop :aggressive Conversion(A::Jacobi, B::Ultraspherical) = _Conversion(A, B)
+    Base.@constprop :aggressive Conversion(A::Ultraspherical, B::Jacobi) = _Conversion(A, B)
+else
+    Conversion(A::Jacobi, B::Ultraspherical) = _Conversion(A, B)
+    Conversion(A::Ultraspherical, B::Jacobi) = _Conversion(A, B)
+end
+
+
+
+bandwidths(::ConcreteConversion{<:Chebyshev,<:Jacobi}) = 0,0
+bandwidths(::ConcreteConversion{<:Jacobi,<:Chebyshev}) = 0,0
+
+
+bandwidths(::ConcreteConversion{<:Ultraspherical,<:Jacobi}) = 0,0
+bandwidths(::ConcreteConversion{<:Jacobi,<:Ultraspherical}) = 0,0
+
+#TODO: Figure out how to unify these definitions
+function getindex(::ConcreteConversion{<:Chebyshev,<:Jacobi,T}, k::Integer, j::Integer) where {T}
+    if j==k
+        one(T)/jacobip(T,k-1,-one(T)/2,-one(T)/2,one(T))
+    else
+        zero(T)
+    end
+end
+
+function BandedMatrix(S::SubOperator{T,ConcreteConversion{CC,J,T},NTuple{2,UnitRange{Int}}}) where {J<:Jacobi,CC<:Chebyshev,T}
+    ret=BandedMatrix(Zeros, S)
+    kr,jr = parentindices(S)
+    k=(kr ∩ jr)
+
+    vals = one(T)./jacobip(T,k .- 1,-one(T)/2,-one(T)/2,one(T))
+
+    ret[band(bandshift(S))] = vals
+    ret
+end
+
+
+function getindex(::ConcreteConversion{<:Jacobi,<:Chebyshev,T}, k::Integer, j::Integer) where {T}
+    if j==k
+        jacobip(T,k-1,-one(T)/2,-one(T)/2,one(T))
+    else
+        zero(T)
+    end
+end
+
+function BandedMatrix(S::SubOperator{T,ConcreteConversion{J,CC,T},NTuple{2,UnitRange{Int}}}) where {J<:Jacobi,CC<:Chebyshev,T}
+    ret=BandedMatrix(Zeros, S)
+    kr,jr = parentindices(S)
+    k=(kr ∩ jr)
+
+    vals = jacobip(T,k.-1,-one(T)/2,-one(T)/2,one(T))
+
+    ret[band(bandshift(S))] = vals
+    ret
+end
+
+
+function getindex(C::ConcreteConversion{<:Ultraspherical,<:Jacobi,T}, k::Integer, j::Integer) where {T}
+    if j==k
+        S=rangespace(C)
+        U=domainspace(C)
+        if S.a == S.b == 0 && isequalhalf(order(U))
+            oneunit(T)
+        else
+            jp=jacobip(T,k-1,S.a,S.b,one(T))
+            um=strictconvert(Operator{T}, Evaluation(setcanonicaldomain(U),RightEndPoint,0))[k]::T
+            (um/jp)::T
+        end
+    else
+        zero(T)
+    end
+end
+
+function BandedMatrix(S::SubOperator{T,ConcreteConversion{US,J,T},NTuple{2,UnitRange{Int}}}) where {US<:Ultraspherical,J<:Jacobi,T}
+    ret=BandedMatrix(Zeros, S)
+    kr,jr = parentindices(S)
+    k=(kr ∩ jr)
+
+    C = parent(S)
+    sp = rangespace(C)
+    U = domainspace(C)
+    if sp.a == 0 && sp.b == 0 && isequalhalf(order(U))
+        ret[band(bandshift(S))] .= oneunit(T)
+    else
+        jp=jacobip(T,k.-1,sp.a,sp.b,one(T))
+        um=Evaluation(T,setcanonicaldomain(U),RightEndPoint,0)[k]
+        vals = um./jp
+
+        ret[band(bandshift(S))] = vals
+    end
+    ret
+end
+
+
+
+function getindex(C::ConcreteConversion{<:Jacobi,<:Ultraspherical,T}, k::Integer, j::Integer) where {T}
+    if j==k
+        S=domainspace(C)
+        U = rangespace(C)
+        if S.a == S.b == 0 && isequalhalf(order(U))
+            oneunit(T)
+        else
+            jp=jacobip(T,k-1,S.a,S.b,one(T))
+            um=Evaluation(T,setcanonicaldomain(rangespace(C)),RightEndPoint,0)[k]
+            jp/um::T
+        end
+    else
+        zero(T)
+    end
+end
+
+function BandedMatrix(S::SubOperator{T,ConcreteConversion{J,US,T},NTuple{2,UnitRange{Int}}}) where {US<:Ultraspherical,J<:Jacobi,T}
+    ret=BandedMatrix(Zeros, S)
+    kr,jr = parentindices(S)
+    k=(kr ∩ jr)
+
+    C = parent(S)
+    sp=domainspace(C)
+    U = rangespace(C)
+    if sp.a == 0 && sp.b == 0 && isequalhalf(order(U))
+        ret[band(bandshift(S))] .= oneunit(T)
+    else
+        jp=jacobip(T,k.-1,sp.a,sp.b,one(T))
+        um=Evaluation(T,setcanonicaldomain(U),RightEndPoint,0)[k]
+        vals = jp./um
+        ret[band(bandshift(S))] = vals
+    end
+    ret
+end
+
+function union_rule(A::Jacobi,B::Jacobi)
+    if domainscompatible(A,B)
+        Jacobi(min(A.b,B.b),min(A.a,B.a),domain(A))
+    else
+        NoSpace()
+    end
+end
+
+function maxspace_rule(A::Jacobi,B::Jacobi)
+    if isapproxinteger(A.a-B.a) && isapproxinteger(A.b-B.b)
+        Jacobi(max(A.b,B.b),max(A.a,B.a),domain(A))
+    else
+        NoSpace()
+    end
+end
+
+
+function union_rule(A::Chebyshev,B::Jacobi)
+    if domainscompatible(A, B)
+        if isapproxminhalf(B.a) && isapproxminhalf(B.b)
+            # the spaces are the same
+            A
+        else
+            union(Jacobi(A),B)
+        end
+    else
+        if isapproxminhalf(B.a) && isapproxminhalf(B.b)
+            union(A, Chebyshev(domain(B)))
+        else
+            NoSpace()
+        end
+    end
+end
+function union_rule(A::Ultraspherical,B::Jacobi)
+    m=order(A)
+    if domainscompatible(A, B)
+        if isapproxminhalf(B.a-m) && isapproxminhalf(B.b-m)
+            # the spaces are the same
+            A
+        else
+            union(Jacobi(A),B)
+        end
+    else
+        if isapproxminhalf(B.a-m) && isapproxminhalf(B.b-m)
+            union(A, Ultraspherical(m, domain(B)))
+        else
+            NoSpace()
+        end
+    end
+end
+
+for (OPrule,OP) in ((:conversion_rule,:conversion_type), (:maxspace_rule,:maxspace))
+    @eval begin
+        function $OPrule(A::Chebyshev,B::Jacobi)
+            if isapproxminhalf(B.a) && isapproxminhalf(B.b)
+                # the spaces are the same
+                A
+            elseif isapproxhalfoddinteger(B.a) && isapproxhalfoddinteger(B.b)
+                $OP(Jacobi(A),B)
+            else
+                NoSpace()
+            end
+        end
+        function $OPrule(A::Ultraspherical,B::Jacobi)
+            m = order(A)
+            if isapproxminhalf(B.a - m) && isapproxminhalf(B.b - m)
+                # the spaces are the same
+                A
+            elseif isapproxhalfoddinteger(B.a) && isapproxhalfoddinteger(B.b)
+                $OP(Jacobi(A),B)
+            else
+                NoSpace()
+            end
+        end
+    end
+end
+
+hasconversion(a::Jacobi,b::Chebyshev) = hasconversion(a,Jacobi(b))
+hasconversion(a::Chebyshev,b::Jacobi) = hasconversion(Jacobi(a),b)
+
+hasconversion(a::Jacobi,b::Ultraspherical) = hasconversion(a,Jacobi(b))
+hasconversion(a::Ultraspherical,b::Jacobi) = hasconversion(Jacobi(a),b)
+
+
+
+
+## Special Multiplication
+# special multiplication operators exist when multiplying by
+# (1+x) or (1-x) by _decreasing_ the parameter.  Thus the
+
+
+
+
+
+
+
+# represents [b+(1+z)*d/dz] (false) or [a-(1-z)*d/dz] (true)
+struct JacobiSD{T} <:Operator{T}
+    lr::Bool
+    S::Jacobi
+end
+
+JacobiSD(lr,S)=JacobiSD{Float64}(lr,S)
+
+convert(::Type{Operator{T}},SD::JacobiSD) where {T}=JacobiSD{T}(SD.lr,SD.S)
+
+domain(op::JacobiSD)=domain(op.S)
+domainspace(op::JacobiSD)=op.S
+rangespace(op::JacobiSD)=op.lr ? Jacobi(op.S.b+1,op.S.a-1,domain(op.S)) : Jacobi(op.S.b-1,op.S.a+1,domain(op.S))
+bandwidths(::JacobiSD)=0,0
+
+function getindex(op::JacobiSD,A,k::Integer,j::Integer)
+    m=op.lr ? op.S.a : op.S.b
+    if k==j
+        k+m-1
+    else
+        zero(eltype(op))
+    end
+end

--- a/test/AFOP/Jacobi/jacobitransform.jl
+++ b/test/AFOP/Jacobi/jacobitransform.jl
@@ -1,0 +1,38 @@
+
+points(S::Jacobi, n) = points(Chebyshev(domain(S)), n)
+
+struct JacobiTransformPlan{T,CPLAN,CJT} <: AbstractTransformPlan{T}
+    chebplan::CPLAN
+    cjtplan::CJT
+end
+
+JacobiTransformPlan(chebplan::CPLAN, cjtplan::CJT) where {CPLAN,CJT} =
+    JacobiTransformPlan{eltype(chebplan),CPLAN,CJT}(chebplan, cjtplan)
+
+plan_transform(S::Jacobi, v::AbstractVector) =
+    JacobiTransformPlan(plan_transform(Chebyshev(), v), plan_cheb2jac(v, S.a, S.b))
+plan_transform!(S::Jacobi, v::AbstractVector) =
+    JacobiTransformPlan(plan_transform!(Chebyshev(), v), plan_cheb2jac(v, S.a, S.b))
+*(P::JacobiTransformPlan, vals::AbstractVector) = lmul!(P.cjtplan, P.chebplan * vals)
+
+
+struct JacobiITransformPlan{T,CPLAN,CJT,inplace} <: AbstractTransformPlan{T}
+    ichebplan::CPLAN
+    icjtplan::CJT
+end
+
+JacobiITransformPlan(chebplan, cjtplan) = JacobiITransformPlan{false}(chebplan, cjtplan)
+JacobiITransformPlan{inplace}(chebplan::CPLAN, cjtplan::CJT) where {CPLAN,CJT,inplace} =
+    JacobiITransformPlan{eltype(chebplan),CPLAN,CJT,inplace}(chebplan, cjtplan)
+
+inplace(J::JacobiITransformPlan{<:Any,<:Any,<:Any,IP}) where {IP} = IP
+
+plan_itransform(S::Jacobi, v::AbstractVector) =
+    JacobiITransformPlan(plan_itransform(Chebyshev(), v), plan_jac2cheb(v, S.a, S.b))
+plan_itransform!(S::Jacobi, v::AbstractVector) =
+    JacobiITransformPlan{true}(plan_itransform!(Chebyshev(), v), plan_jac2cheb(v, S.a, S.b))
+icjt(P, cfs, ::Val{true}) = lmul!(P, cfs)
+icjt(P, cfs, ::Val{false}) = P * cfs
+function *(P::JacobiITransformPlan, cfs::AbstractVector)
+    P.ichebplan * icjt(P.icjtplan, cfs, Val(inplace(P)))
+end

--- a/test/AFOP/PolynomialSpaces.jl
+++ b/test/AFOP/PolynomialSpaces.jl
@@ -1,0 +1,754 @@
+module PolynomialSpaces
+
+using ApproxFunBase
+
+using Base, LinearAlgebra, BandedMatrices, BlockBandedMatrices,
+            BlockArrays, FillArrays, FastTransforms,
+            DomainSets, Statistics, FastGaussQuadrature, Static,
+            SpecialFunctions
+
+import ApproxFunBase: Fun, SubSpace, WeightSpace, NoSpace, HeavisideSpace,
+                    IntervalOrSegment, AnyDomain, ArraySpace,
+                    AbstractTransformPlan, TransformPlan, ITransformPlan,
+                    ConcreteConversion, ConcreteMultiplication, ConcreteDerivative,
+                    ConcreteDefiniteIntegral, ConcreteDefiniteLineIntegral,
+                    ConcreteVolterra, Volterra, Evaluation, EvaluationWrapper,
+                    MultiplicationWrapper, ConversionWrapper, DerivativeWrapper,
+                    Conversion, defaultcoefficients, default_Fun, Multiplication,
+                    Derivative, bandwidths, ConcreteEvaluation, ConcreteIntegral,
+                    DefiniteLineIntegral, DefiniteIntegral, IntegralWrapper,
+                    ReverseOrientation, ReverseOrientationWrapper, ReverseWrapper,
+                    Reverse, NegateEven, Dirichlet, ConcreteDirichlet,
+                    TridiagonalOperator, SubOperator, Space, @containsconstants, spacescompatible,
+                    canonicalspace, domain, setdomain, prectype, domainscompatible,
+                    plan_transform, plan_itransform, plan_transform!, plan_itransform!,
+                    transform, itransform, hasfasttransform,
+                    CanonicalTransformPlan, ICanonicalTransformPlan,
+                    Integral, domainspace, rangespace, boundary,
+                    maxspace, hasconversion, points,
+                    union_rule, conversion_rule, maxspace_rule, conversion_type,
+                    linesum, differentiate, integrate, linebilinearform, bilinearform,
+                    Segment, IntervalOrSegmentDomain, PiecewiseSegment, isambiguous,
+                    eps, isperiodic, arclength, complexlength,
+                    invfromcanonicalD, fromcanonical, tocanonical, fromcanonicalD,
+                    tocanonicalD, canonicaldomain, setcanonicaldomain, mappoint,
+                    reverseorientation, checkpoints, evaluate, extrapolate, mul_coefficients,
+                    coefficients, isconvertible, clenshaw, ClenshawPlan,
+                    toeplitz_axpy!, sym_toeplitz_axpy!, hankel_axpy!,
+                    ToeplitzOperator, SymToeplitzOperator, SpaceOperator, cfstype,
+                    alternatesign!, mobius, chebmult_getindex, intpow, alternatingsum,
+                    extremal_args, chebyshev_clenshaw, recA, recB, recC, roots,
+                    diagindshift, rangetype, weight, isapproxinteger, default_Dirichlet, scal!,
+                    components, promoterangespace,
+                    block, blockstart, blockstop, blocklengths, isblockbanded,
+                    pointscompatible, affine_setdiff, complexroots,
+                    ℓ⁰, recα, recβ, recγ, ℵ₀, ∞, RectDomain,
+                    assert_integer, supportsinplacetransform, ContinuousSpace, SpecialEvalPtType,
+                    isleftendpoint, isrightendpoint, evaluation_point, boundaryfn, ldiffbc, rdiffbc,
+                    LeftEndPoint, RightEndPoint, normalizedspace, promotedomainspace,
+                    bandmatrices_eigen, SymmetricEigensystem, SkewSymmetricEigensystem
+
+
+import BandedMatrices: bandshift, bandwidth, colstop, bandwidths, BandedMatrix
+
+using StaticArrays
+
+import Base: convert, getindex, eltype, <, <=, +, -, *, /, ^, ==,
+                show, stride, sum, cumsum, conj, inv,
+                complex, exp, sqrt, abs, sign, issubset,
+                first, last, rand, intersect, setdiff,
+                isless, union, angle, isnan, isapprox, isempty,
+                minimum, maximum, extrema, zeros, one, promote_rule,
+                getproperty, real, imag, max, min, log, acos,
+                sin, cos, asinh, acosh, atanh, ones,
+                Matrix, size
+                # atan, tan, tanh, asin, sec, sinh, cosh,
+                # split
+
+import DomainSets: Domain, indomain, UnionDomain, FullSpace, Point,
+            Interval, ChebyshevInterval, boundary, rightendpoint, leftendpoint,
+            dimension, WrappedDomain
+
+using FastTransforms: plan_chebyshevtransform, plan_chebyshevtransform!,
+                        plan_ichebyshevtransform, plan_ichebyshevtransform!,
+                        pochhammer, lgamma
+
+import BlockBandedMatrices: blockbandwidths
+
+import LinearAlgebra: isdiag
+
+using OddEvenIntegers
+using HalfIntegers
+
+export Chebyshev, Ultraspherical, Jacobi, Legendre
+export NormalizedPolynomialSpace
+export NormalizedChebyshev, NormalizedUltraspherical, NormalizedLegendre, NormalizedJacobi
+
+points(d::IntervalOrSegmentDomain{T},n::Integer) where {T} =
+    _maybefromcanonical(d, chebyshevpoints(float(real(eltype(T))), n))  # eltype to handle point
+_maybefromcanonical(d, pts) = fromcanonical.(Ref(d), pts)
+_maybefromcanonical(::ChebyshevInterval, pts::FastTransforms.ChebyshevGrid) = pts
+function _maybefromcanonical(d::IntervalOrSegment{<:Union{Number, SVector}}, pts::FastTransforms.ChebyshevGrid)
+    shift = mean(d)
+    scale = complexlength(d) / 2
+    ShiftedChebyshevGrid(pts, shift, scale)
+end
+
+struct ShiftedChebyshevGrid{T, S, C<:FastTransforms.ChebyshevGrid} <: AbstractVector{T}
+    grid :: C
+    shift :: S
+    scale :: S
+end
+function ShiftedChebyshevGrid(grid::G, shift::S, scale::S) where {G,S}
+    T = typeof(zero(eltype(G)) * zero(S))
+    ShiftedChebyshevGrid{T,S,G}(grid, shift, scale)
+end
+size(S::ShiftedChebyshevGrid) = size(S.grid)
+Base.@propagate_inbounds getindex(S::ShiftedChebyshevGrid, i::Int) = S.shift + S.grid[i] * S.scale
+function Base.showarg(io::IO, S::ShiftedChebyshevGrid, toplevel::Bool)
+    print(io, "ShiftedChebyshevGrid{", eltype(S), "}")
+end
+
+strictconvert(T::Type, x) = convert(T, x)::T
+
+
+# If any of the orders is an Integer, use == for an exact comparison, else fall back to isapprox
+# We assume that Integer orders are deliberately chosen to be exact
+compare_op(::Union{Integer, HalfInteger}, args...) = ==
+compare_op() = ≈
+compare_op(::Any, args...) = compare_op(args...)
+compare_orders(a::Number, b::Number) = compare_op(a, b)(a, b)
+
+# work around type promotions to preserve types for StepRanges involving HalfOddIntegers with a unit step
+const HalfOddInteger{T<:Integer} = Half{Odd{T}}
+
+# return 1/2, possibly preserving types but not being too fussy
+_onehalf(x) = onehalf(x)
+_onehalf(::Union{StaticInt, StaticFloat64}) = static(0.5)
+_onehalf(::Integer) = half(Odd(1))
+
+# return -1/2, possibly preserving types but not being too fussy
+_minonehalf(x) = -onehalf(x)
+_minonehalf(@nospecialize(_::Union{StaticInt, StaticFloat64})) = static(-0.5)
+_minonehalf(::Integer) = half(Odd(-1))
+
+isapproxminhalf(a) = a ≈ _minonehalf(a)
+isapproxminhalf(@nospecialize(a::StaticInt)) = isequalminhalf(a)
+isapproxminhalf(::Integer) = false
+
+isequalminhalf(x) = x == _minonehalf(x)
+isequalminhalf(@nospecialize(a::StaticInt)) = false
+isequalminhalf(::Integer) = false
+
+isequalhalf(x) = x == _onehalf(x)
+isequalhalf(@nospecialize(a::StaticInt)) = false
+isequalhalf(x::Integer) = false
+
+isapproxhalfoddinteger(a) = !isapproxinteger(a) && isapproxinteger(a+_onehalf(a))
+isapproxhalfoddinteger(a::HalfOddInteger) = true
+isapproxhalfoddinteger(@nospecialize(a::StaticInt)) = false
+function isapproxhalfoddinteger(a::StaticFloat64)
+    x = mod(a, static(1))
+    x == _onehalf(x) || dynamic(x) ≈ 0.5
+end
+isapproxhalfoddinteger(::Integer) = false
+
+## Orthogonal polynomials
+
+abstract type PolynomialSpace{D,R} <: Space{D,R} end
+
+@containsconstants PolynomialSpace
+
+Multiplication(f::Fun{U},sp::PolynomialSpace) where {U<:PolynomialSpace} = ConcreteMultiplication(f,sp)
+bandwidths(M::ConcreteMultiplication{U,V}) where {U<:PolynomialSpace,V<:PolynomialSpace} =
+    (ncoefficients(M.f)-1,ncoefficients(M.f)-1)
+rangespace(M::ConcreteMultiplication{U,V}) where {U<:PolynomialSpace,V<:PolynomialSpace} = domainspace(M)
+
+
+
+
+## Evaluation
+
+function evaluate(f::AbstractVector,S::PolynomialSpace,x)
+    if x in domain(S)
+        clenshaw(S,f,tocanonical(S,x))
+    elseif isambiguous(domain(S))
+        length(f) == 0 && return zero(eltype(f))
+        for k = 2:length(f)
+            iszero(f[k]) || throw(ArgumentError("Ambiguous domains only work with constants"))
+        end
+        return first(f)
+    else
+        zero(eltype(f))
+    end
+end
+
+# we need the ... for multi-dimensional
+evaluate(f::AbstractVector,S::PolynomialSpace,x,y,z...) =
+    evaluate(f,S,SVector(x,y,z...))
+
+function evaluate(f::AbstractVector, S::PolynomialSpace, x::Fun)
+    if issubset(Interval(minimum(x),maximum(x)),domain(S))
+        clenshaw(S,f,tocanonical(S,x))
+    else
+        error("Implement splitatpoints for evaluate ")
+    end
+end
+
+## Extrapolation
+extrapolate(f::AbstractVector,S::PolynomialSpace,x) = clenshaw(S,f,tocanonical(S,x))
+
+######
+# Recurrence encodes the recurrence coefficients
+# or equivalently multiplication by x
+######
+struct Recurrence{S,T} <: TridiagonalOperator{T}
+    space::S
+end
+
+Recurrence(sp) = Recurrence{typeof(sp),rangetype(sp)}(sp)
+
+convert(::Type{Operator{T}},J::Recurrence{S}) where {T,S} = Recurrence{S,T}(J.space)
+
+domainspace(R::Recurrence) = R.space
+rangespace(R::Recurrence) = R.space
+
+
+#####
+# recα/β/γ are given by
+#       x p_{n-1} =γ_n p_{n-2} + α_n p_{n-1} +  p_n β_n
+#####
+
+function getindex(R::Recurrence{S,T},k::Integer,j::Integer) where {S,T}
+    if j==k-1
+        recβ(T,R.space,k-1)
+    elseif j==k
+        recα(T,R.space,k)
+    elseif j==k+1
+        recγ(T,R.space,k+1)
+    else
+        zero(T)
+    end
+end
+
+######
+# JacobiZ encodes [BasisFunctional(1);(J-z*I)[2:end,:]]
+# where J is the Jacobi operator
+######
+struct JacobiZ{S<:Space,T} <: TridiagonalOperator{T}
+    space::S
+    z::T
+end
+
+JacobiZ(sp::PolynomialSpace,z) =
+    (T = promote_type(prectype(sp),typeof(z)); JacobiZ{typeof(sp),T}(sp,strictconvert(T,z)))
+
+convert(::Type{Operator{T}},J::JacobiZ{S}) where {T,S} = JacobiZ{S,T}(J.space,J.z)
+
+domainspace(::JacobiZ) = ℓ⁰
+rangespace(::JacobiZ) = ℓ⁰
+
+#####
+# recα/β/γ are given by
+#       x p_{n-1} =γ_n p_{n-2} + α_n p_{n-1} +  p_n β_n
+#####
+
+function getindex(J::JacobiZ{S,T},k::Integer,j::Integer) where {S,T}
+    if j==k-1
+        recγ(T,J.space,k)
+    elseif j==k
+        k == 1 ? one(T) : recα(T,J.space,k)-J.z
+    elseif j==k+1 && k > 1
+        recβ(T,J.space,k)
+    else
+        zero(T)
+    end
+end
+
+
+
+
+#####
+# Multiplication can be built from recurrence coefficients
+#  multiplication by J=M[x] is Recurrence operator
+#  and assume p_0 = 1, then we have
+#
+#   M[p_0] = 1
+#   M[p_1] = (J/β_1 - α_1/β_1)*M[p_0]
+#   M[p_k] = (J/β_k - α_k/β_k)*M[p_{k-1}] - γ_k/β_k*M[p_{k-2}]
+#####
+
+
+getindex(M::ConcreteMultiplication{C,PS,T},k::Integer,j::Integer) where {PS<:PolynomialSpace,T,C<:PolynomialSpace} = M[k:k,j:j][1,1]
+
+if view(brand(0,0,0,0), band(0)) isa BandedMatrices.BandedMatrixBand
+    dataview(V) = BandedMatrices.dataview(V)
+else
+#=
+dataview is broken on BandedMatrices v0.17.6 and older.
+We copy the function over from BandedMatrices.jl, which is distributed under the MIT license
+See https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/blob/master/LICENSE
+=#
+    function dataview(V)
+        A = parent(parent(V))
+        b = first(parentindices(V)).band.i
+        m,n = size(A)
+        l,u = bandwidths(A)
+        data = BandedMatrices.bandeddata(A)
+        view(data, u - b + 1, max(b,0)+1:min(n,m+b))
+    end
+end
+
+_view(::Any, A, b) = view(A, b)
+_view(::Val{true}, A::BandedMatrix, b) = dataview(view(A, b))
+
+function _get_bands(B, C, bmk, f, ValBC)
+    Cbmk = _view(Val(true), C, band(bmk*f))
+    Bm = _view(Val(true), B, band(flipsign(bmk-1, f)))
+    B0 = _view(Val(true), B, band(flipsign(bmk, f)))
+    Bp = _view(ValBC, B, band(flipsign(bmk+1, f)))
+    Cbmk, Bm, B0, Bp
+end
+
+function _jac_gbmm!(α, J, B, β, C, b, (Cn, Cm), n, ValJ, ValBC)
+    Jp = _view(ValJ, J, band(1))
+    J0 = _view(ValJ, J, band(0))
+    Jm = _view(ValJ, J, band(-1))
+
+    kr = intersect(-1:b-1, b-Cm+1:b-1+Cn)
+
+    # unwrap the loops to forward indexing to the data wherever applicable
+    # this might also help with cache localization
+    k = -1
+    if k in kr
+        Cbmk, Bm, B0, Bp = _get_bands(B, C, b-k, 1, ValBC)
+        for i in 1:n-b+k
+            Cbmk[i] += α * Bm[i+1] * Jp[i]
+        end
+    end
+
+    k = 0
+    if k in kr
+        Cbmk, Bm, B0, Bp = _get_bands(B, C, b-k, 1, Val(true))
+        for i in 1:n-b+k
+            Cbmk[i] += α * (Bm[i+1] * Jp[i] + B0[i] * J0[i])
+        end
+    end
+
+    for k in max(1, first(kr)):last(kr)
+        Cbmk, Bm, B0, Bp = _get_bands(B, C, b-k, 1, Val(true))
+        Cbmk[1] += α * (Bm[2] * Jp[1] + B0[1] * J0[1])
+        for i in 2:n-b+k
+            Cbmk[i] += α * (Bm[i+1] * Jp[i] + B0[i] * J0[i] + Bp[i-1] * Jm[i-1])
+        end
+    end
+
+    kr = intersect(-1:b-1, 1-Cn+b:Cm-1+b)
+
+    k = -1
+    if k in kr
+        Ckmb, Bp, B0, Bm = _get_bands(B, C, b-k, -1, ValBC)
+        for (i, Ji) in enumerate(b-k:n-1)
+            Ckmb[i] += α * Bp[i] * Jm[Ji]
+        end
+    end
+
+    k = 0
+    if k in kr
+        Ckmb, Bp, B0, Bm = _get_bands(B, C, b-k, -1, Val(true))
+        Ckmb[1] += α * Bp[1] * Jm[b-k]
+        for (i, Ji) in enumerate(b-k+1:n-1)
+            Ckmb[i] += α * B0[i] * J0[Ji]
+            Ckmb[i+1] += α * Bp[i+1] * Jm[Ji]
+        end
+        Ckmb[n-(b-k)] += α * B0[n-(b-k)] * J0[n]
+    end
+
+    for k = max(1, first(kr)):last(kr)
+        Ckmb, Bp, B0, Bm = _get_bands(B, C, b-k, -1, Val(true))
+        Ckmb[1] += α * Bp[1] * Jm[b-k]
+        for (i, Ji) in enumerate(b-k+1:n-1)
+            Ckmb[i] += α * (Bm[i] * Jp[Ji] + B0[i] * J0[Ji])
+            Ckmb[i+1] += α * Bp[i+1] * Jm[Ji]
+        end
+        Ckmb[n-(b-k)] += α * B0[n-(b-k)] * J0[n]
+    end
+
+    C0 = _view(Val(true), C, band(0))
+    Bm = _view(Val(true), B, band(-1))
+    Bp = _view(Val(true), B, band(1))
+    B0 = _view(Val(true), B, band(0))
+    for i in 1:n-1
+        C0[i] += α * (B0[i] * J0[i] + Bm[i] * Jp[i])
+        C0[i+1] += α * Bp[i] * Jm[i]
+    end
+    C0[n] += α * B0[n] * J0[n]
+
+    return C
+end
+
+# Fast implementation of C[:,:] = α*J*B+β*C where the bandediwth of B is
+# specified by b, not by the parameters in B
+function jac_gbmm!(α, J, B, β, C, b, valJ, valBC)
+    if β ≠ 1
+        lmul!(β,C)
+    end
+
+    n = size(J,1)
+    Cn, Cm = size(C)
+
+    _jac_gbmm!(α, J, B, β, C, b, (Cn, Cm), n, valJ, valBC)
+
+    C
+end
+
+function BandedMatrix(S::SubOperator{T,ConcreteMultiplication{C,PS,T},
+                                     NTuple{2,UnitRange{Int}}}) where {PS<:PolynomialSpace,T,C<:PolynomialSpace}
+    M=parent(S)
+    kr,jr=parentindices(S)
+    f=M.f
+    a=f.coefficients
+    sp=space(f)
+    n=length(a)
+
+    if n==0
+        return BandedMatrix(Zeros, S)
+    elseif n==1
+        ret = BandedMatrix(Zeros, S)
+        shft=kr[1]-jr[1]
+        ret[band(shft)] .= a[1]
+        return ret
+    elseif n==2
+        # we have U_x = [1 α-x; 0 β]
+        # for e_1^⊤ U_x\a == a[1]*I-(α-J)*a[2]/β == (a[1]-α*a[2]/β)*I + J*a[2]/β
+        # implying
+        α,β=recα(T,sp,1),recβ(T,sp,1)
+        ret=Operator{T}(Recurrence(M.space))[kr,jr]
+        lmul!(a[2]/β,ret)
+        shft=kr[1]-jr[1]
+        @views ret[band(shft)] .+= a[1]-α*a[2]/β
+        return ret
+    end
+
+    jkr=max(1,min(jr[1],kr[1])-(n-1)÷2):max(jr[end],kr[end])+(n-1)÷2
+
+    #Multiplication is transpose
+    J=Operator{T}(Recurrence(M.space))[jkr,jkr]
+    valJ = all(>=(1), bandwidths(J)) ? Val(true) : Val(false)
+
+    B=n-1  # final bandwidth
+
+    # Clenshaw for operators
+    Bk2 = BandedMatrix(Zeros{T}(size(J)), (B,B))
+    dataview(view(Bk2, band(0))) .= a[n]/recβ(T,sp,n-1)
+    α,β = recα(T,sp,n-1),recβ(T,sp,n-2)
+    Bk1 = (-α/β)*Bk2
+    dataview(view(Bk1, band(0))) .+= a[n-1]/β
+    jac_gbmm!(one(T)/β,J,Bk2,one(T),Bk1,0,valJ, Val(true))
+    b=1  # we keep track of bandwidths manually to reuse memory
+    for k=n-2:-1:2
+        α,β,γ=recα(T,sp,k),recβ(T,sp,k-1),recγ(T,sp,k+1)
+        lmul!(-γ/β,Bk2)
+        dataview(view(Bk2, band(0))) .+= a[k]/β
+        jac_gbmm!(1/β,J,Bk1,one(T),Bk2,b,valJ,Val(true))
+        LinearAlgebra.axpy!(-α/β,Bk1,Bk2)
+        Bk2,Bk1=Bk1,Bk2
+        b+=1
+    end
+    α,γ=recα(T,sp,1),recγ(T,sp,2)
+    lmul!(-γ,Bk2)
+    dataview(view(Bk2, band(0))) .+= a[1]
+    jac_gbmm!(one(T),J,Bk1,one(T),Bk2,b,valJ,Val(false))
+    LinearAlgebra.axpy!(-α,Bk1,Bk2)
+
+    # relationship between jkr and kr, jr
+    kr2,jr2=kr.-jkr[1].+1,jr.-jkr[1].+1
+
+    # TODO: reuse memory of Bk2, though profile suggests it's not too important
+    BandedMatrix(view(Bk2,kr2,jr2))
+end
+
+
+
+
+## All polynomial spaces can be converted provided spaces match
+
+isconvertible(a::PolynomialSpace,b::PolynomialSpace) = domain(a) == domain(b)
+union_rule(a::PolynomialSpace{D},b::PolynomialSpace{D}) where {D} =
+    domainscompatible(a,b) ? (a < b ? a : b) : NoSpace()   # the union of two polys is always a poly
+
+
+
+## General clenshaw
+clenshaw(sp::PolynomialSpace,c::AbstractVector,x::AbstractArray) = clenshaw(c,x,
+                                            ClenshawPlan(promote_type(eltype(c),eltype(x)),sp,length(c),length(x)))
+clenshaw(sp::PolynomialSpace,c::AbstractMatrix,x::AbstractArray) = clenshaw(c,x,ClenshawPlan(promote_type(eltype(c),eltype(x)),sp,size(c,1),length(x)))
+clenshaw(sp::PolynomialSpace,c::AbstractMatrix,x) = clenshaw(c,x,ClenshawPlan(promote_type(eltype(c),typeof(x)),sp,size(c,1),size(c,2)))
+
+clenshaw!(sp::PolynomialSpace,c::AbstractVector,x::AbstractVector)=clenshaw!(c,x,ClenshawPlan(promote_type(eltype(c),eltype(x)),sp,length(x)))
+
+function clenshaw(sp::PolynomialSpace,c::AbstractVector,x)
+    N,T = length(c),promote_type(prectype(sp),eltype(c),typeof(x))
+    TT = eltype(T)
+    if isempty(c)
+        return zero(T)
+    end
+
+    bk1,bk2 = zero(T),zero(T)
+    A,B,C = recA(TT,sp,N-1),recB(TT,sp,N-1),recC(TT,sp,N)
+    for k = N:-1:2
+        bk2, bk1 = bk1, muladd(muladd(A,x,B),bk1,muladd(-C,bk2,c[k])) # muladd(-C,bk2,muladd(muladd(A,x,B),bk1,c[k])) # (A*x+B)*bk1+c[k]-C*bk2
+        A,B,C = recA(TT,sp,k-2),recB(TT,sp,k-2),recC(TT,sp,k-1)
+    end
+    muladd(muladd(A,x,B),bk1,muladd(-C,bk2,c[1])) # muladd(-C,bk2,muladd(muladd(A,x,B),bk1,c[1])) # (A*x+B)*bk1+c[1]-C*bk2
+end
+
+
+
+# evaluate polynomial
+# indexing starts from 0
+function forwardrecurrence(::Type{T},S::Space,r::AbstractRange,x::Number) where T
+    if isempty(r)
+        return T[]
+    end
+    n=maximum(r)+1
+    v=Vector{T}(undef, n)  # x may be complex
+    if n > 0
+        v[1]=1
+        if n > 1
+            v[2] = muladd(recA(T,S,0),x,recB(T,S,0))
+            @inbounds for k=2:n-1
+                v[k+1]=muladd(muladd(recA(T,S,k-1),x,recB(T,S,k-1)),v[k],-recC(T,S,k-1)*v[k-1])
+            end
+        end
+    end
+
+    return v[r.+1]
+end
+
+getindex(op::ConcreteEvaluation{<:PolynomialSpace}, k::Integer) = op[k:k][1]
+
+_evalpt(op, x::Number) = x
+_evalpt(op, x::SpecialEvalPtType) = boundaryfn(x)(domain(op))
+
+function getindex(op::ConcreteEvaluation{<:PolynomialSpace},kr::AbstractRange)
+    _getindex_evaluation(eltype(op), op.space, op.order, _evalpt(op, evaluation_point(op)), kr)
+end
+
+function _getindex_evaluation(::Type{T}, sp, order, x, kr::AbstractRange) where {T}
+    Base.require_one_based_indexing(kr)
+    isempty(kr) && return zeros(T, 0)
+    if order == 0
+        forwardrecurrence(T,sp,kr .- 1,tocanonical(sp,x))
+    else
+        z = Zeros{T}(length(range(minimum(kr), order, step=step(kr))))
+        kr_red = kr .- (order + 1)
+        polydegrees = reverse(range(maximum(kr_red), max(0, minimum(kr_red)), step=-step(kr)))
+        D = Derivative(sp, order)
+        if !isempty(polydegrees)
+            P = forwardrecurrence(T, rangespace(D), polydegrees, tocanonical(sp,x))
+            # in case the derivative has only one non-zero band, the matrix-vector
+            # multiplication simplifies considerably.
+            # This branch is particularly useful for ConcreteDerivatives where
+            # indexing is fast, as the non-zero band may be computed without
+            # evaluating the matrix
+            if bandwidth(D, 1) == -bandwidth(D, 2)
+                d = nonzeroband(T, D, polydegrees, order)
+                Pd = P .* d
+                if !isempty(z)
+                    Pd = T[z; Pd]
+                end
+            else
+                # in general, this is a banded matrix-vector product
+                Dtv = view(transpose(D), kr, 1:length(P))
+                Pd = strictconvert(Vector{T},  mul_coefficients(Dtv, P))
+            end
+        else
+            Pd = T[z;]
+        end
+        Pd
+    end
+end
+
+function nonzeroband(::Type{T}, D::ConcreteDerivative, polydegrees, order) where {T}
+    bw = bandwidth(D, 2)
+    T[D[k+1, k+1+bw] for k in polydegrees]
+end
+function nonzeroband(::Type{T}, D, polydegrees, order) where {T}
+    bw = bandwidth(D, 2)
+    rows = 1:(maximum(polydegrees) + order + 1)
+    B = D[rows, rows .+ bw]
+    Bv = @view B[diagind(B)]
+    Bv[polydegrees .+ 1]
+end
+
+
+struct NormalizedPolynomialSpace{S,D,R} <: Space{D,R}
+    space::S
+    NormalizedPolynomialSpace{S,D,R}(space) where {S,D,R} = new{S,D,R}(space)
+end
+
+@containsconstants NormalizedPolynomialSpace
+
+domain(S::NormalizedPolynomialSpace) = domain(S.space)
+canonicalspace(S::NormalizedPolynomialSpace) = S.space
+setdomain(NS::NormalizedPolynomialSpace, d::Domain) = NormalizedPolynomialSpace(setdomain(canonicalspace(NS), d))
+
+NormalizedPolynomialSpace(space::PolynomialSpace{D,R}) where {D,R} = NormalizedPolynomialSpace{typeof(space),D,R}(space)
+
+normalizedspace(S::PolynomialSpace) = NormalizedPolynomialSpace(S)
+normalizedspace(S::NormalizedPolynomialSpace) = S
+
+supportsinplacetransform(N::NormalizedPolynomialSpace) = supportsinplacetransform(N.space)
+
+function Conversion(L::NormalizedPolynomialSpace{S}, M::S) where S<:PolynomialSpace
+    if L.space == M
+        ConcreteConversion(L, M)
+    else
+        sp = L.space
+        ConversionWrapper(TimesOperator(Conversion(sp, M), ConcreteConversion(L, sp)))
+    end
+end
+
+function Conversion(L::S, M::NormalizedPolynomialSpace{S}) where S<:PolynomialSpace
+    if M.space == L
+        ConcreteConversion(L, M)
+    else
+        sp = M.space
+        ConversionWrapper(TimesOperator(ConcreteConversion(sp, M), Conversion(L, sp)))
+    end
+end
+
+function Conversion(L::NormalizedPolynomialSpace{<:PolynomialSpace},
+        M::NormalizedPolynomialSpace{<:PolynomialSpace})
+
+    L == M && return Conversion(L)
+
+    C1 = ConcreteConversion(L, canonicalspace(L))
+    C2 = Conversion(canonicalspace(L), canonicalspace(M))
+    C3 = ConcreteConversion(canonicalspace(M), M)
+    ConversionWrapper(C3 * C2 * C1, L, M)
+end
+
+function Fun(::typeof(identity), S::NormalizedPolynomialSpace)
+    C = canonicalspace(S)
+    f = Fun(identity, C)
+    coeffs = coefficients(f)
+    CS = ConcreteConversion(C, S)
+    ApproxFunBase.mul_coefficients!(CS, coeffs)
+    Fun(S, coeffs)
+end
+
+function conversion_rule(a::NormalizedPolynomialSpace{S}, b::S) where S<:PolynomialSpace
+    conversion_type(a.space, b)
+end
+
+function maxspace_rule(a::NormalizedPolynomialSpace{S}, b::S) where S<:PolynomialSpace
+    maxspace(a.space, b)
+end
+
+bandwidths(C::ConcreteConversion{NormalizedPolynomialSpace{S,D,R},S}) where {S,D,R} = (0, 0)
+bandwidths(C::ConcreteConversion{S,NormalizedPolynomialSpace{S,D,R}}) where {S,D,R} = (0, 0)
+
+function getindex(C::ConcreteConversion{NormalizedPolynomialSpace{S,D,R},S,T},k::Integer,j::Integer) where {S,D<:IntervalOrSegment,R,T}
+    if j==k
+        inv(sqrt(normalization(T, C.rangespace, k-1)*arclength(domain(C.rangespace))/2))
+    else
+        zero(T)
+    end
+end
+
+function getindex(C::ConcreteConversion{S,NormalizedPolynomialSpace{S,D,R},T},k::Integer,j::Integer) where {S,D<:IntervalOrSegment,R,T}
+    if j==k
+        sqrt(normalization(T, C.domainspace, k-1)*arclength(domain(C.domainspace))/2)
+    else
+        zero(T)
+    end
+end
+
+function getindex(op::ConcreteEvaluation{<:NormalizedPolynomialSpace}, k::Integer)
+    S = domainspace(op)
+    ec = Evaluation(canonicalspace(S), op.x, op.order)[k]
+    nrm = ConcreteConversion(S, canonicalspace(S))[k,k]
+    nrm * ec
+end
+function getindex(op::ConcreteEvaluation{<:NormalizedPolynomialSpace}, kr::AbstractRange)
+    S = domainspace(op)
+    ec = Evaluation(canonicalspace(S), op.x, op.order)[kr]
+    C = ConcreteConversion(S, canonicalspace(S))
+    nrm = [C[k,k] for k in kr]
+    nrm .* ec
+end
+
+spacescompatible(a::NormalizedPolynomialSpace,b::NormalizedPolynomialSpace) = spacescompatible(a.space,b.space)
+hasconversion(a::PolynomialSpace,b::NormalizedPolynomialSpace) = hasconversion(a,b.space)
+hasconversion(a::NormalizedPolynomialSpace,b::PolynomialSpace) = hasconversion(a.space,b)
+hasconversion(a::NormalizedPolynomialSpace,b::NormalizedPolynomialSpace) = hasconversion(a.space,b)
+
+function isdiag(D::DerivativeWrapper{<:Operator, <:NormalizedPolynomialSpace})
+    sp = domainspace(D)
+    csp = canonicalspace(sp)
+    isdiag(Derivative(csp, D.order))
+end
+
+# Tensor products of normalized and unnormalized spaces may have banded conversions defined
+# A banded conversion exists in special cases, where both conversion operators are diagonal
+_stripnorm(N::NormalizedPolynomialSpace) = canonicalspace(N)
+_stripnorm(x::PolynomialSpace) = x
+function _hasconversion_tensor(A, B)
+    A1, A2 = A
+    B1, B2 = B
+
+    _stripnorm(A1) == _stripnorm(B1) && _stripnorm(A2) == _stripnorm(B2)
+end
+const MaybeNormalized{S<:PolynomialSpace} = Union{S, NormalizedPolynomialSpace{S}}
+const MaybeNormalizedTensorSpace{P1,P2} = TensorSpace{<:Tuple{MaybeNormalized{P1},MaybeNormalized{P2}}}
+
+function hasconversion(A::MaybeNormalizedTensorSpace{<:P1, <:P2},
+        B::MaybeNormalizedTensorSpace{<:P1, <:P2}) where {P1<:PolynomialSpace,P2<:PolynomialSpace}
+
+    _hasconversion_tensor(factors(A), factors(B))
+end
+
+
+function Multiplication(f::Fun{<:PolynomialSpace}, sp::NormalizedPolynomialSpace)
+    unnorm_sp = canonicalspace(sp)
+    O = ConcreteConversion(unnorm_sp,sp) *
+            Multiplication(f,unnorm_sp) * ConcreteConversion(sp, unnorm_sp)
+    MultiplicationWrapper(f, O, sp)
+end
+
+function Multiplication(f::Fun{<:NormalizedPolynomialSpace}, sp::PolynomialSpace)
+    Multiplication(ConcreteConversion(space(f), canonicalspace(f))*f, sp)
+end
+
+function Multiplication(f::Fun{<:NormalizedPolynomialSpace}, sp::NormalizedPolynomialSpace)
+    fc = ConcreteConversion(space(f), canonicalspace(f))*f
+    Multiplication(fc, sp)
+end
+
+ApproxFunBase.hasconcreteconversion_canonical(
+    @nospecialize(::NormalizedPolynomialSpace), @nospecialize(_)) = true
+
+rangespace(M::MultiplicationWrapper{<:PolynomialSpace,
+        <:NormalizedPolynomialSpace}) = domainspace(M)
+
+include("Chebyshev/Chebyshev.jl")
+include("Ultraspherical/Ultraspherical.jl")
+include("Jacobi/Jacobi.jl")
+
+Space(d::IntervalOrSegment) = Chebyshev(d)
+
+# TODO: mode these functions to ApproxFunBase
+function Fun(::typeof(identity), d::IntervalOrSegment{<:Number})
+    Fun(Space(d), [mean(d), complexlength(d)/2])
+end
+
+# the default domain space is higher to avoid negative ultraspherical spaces
+function Integral(d::IntervalOrSegment, n::Number)
+    assert_integer(n)
+    Integral(Ultraspherical(1,d), n)
+end
+
+
+end

--- a/test/AFOP/Ultraspherical/Ultraspherical.jl
+++ b/test/AFOP/Ultraspherical/Ultraspherical.jl
@@ -1,0 +1,140 @@
+export Ultraspherical, NormalizedUltraspherical
+
+#Ultraspherical Spaces
+
+
+"""
+`Ultraspherical(λ)` is the space spanned by the ultraspherical polynomials
+```
+    C_0^{(λ)}(x),C_1^{(λ)}(x),C_2^{(λ)}(x),…
+```
+Note that `λ=1` this reduces to Chebyshev polynomials of the second kind:
+`C_k^{(1)}(x) = U_k(x)`.
+For `λ=1/2` this also reduces to Legendre polynomials:
+`C_k^{(1/2)}(x) = P_k(x)`.
+"""
+struct Ultraspherical{T,D<:Domain,R} <: PolynomialSpace{D,R}
+    order::T
+    domain::D
+    Ultraspherical{T,D,R}(m::T,d::D) where {T,D,R} = (@assert m ≠ 0; new(m,d))
+    Ultraspherical{T,D,R}(m::Number,d::Domain) where {T,D,R} = (@assert m ≠ 0; new(strictconvert(T,m),strictconvert(D,d)))
+    Ultraspherical{T,D,R}(d::Domain) where {T,D,R} = new(one(T),strictconvert(D,d))
+    Ultraspherical{T,D,R}(m::Number) where {T,D,R} = (@assert m ≠ 0; new(strictconvert(T,m),D()))
+end
+
+Ultraspherical(m::Number,d::Domain) = Ultraspherical{typeof(m),typeof(d),real(prectype(d))}(m,d)
+Ultraspherical(m::Number,d) = Ultraspherical(m,Domain(d))
+Ultraspherical(m::Number) = Ultraspherical(m,ChebyshevInterval())
+const NormalizedUltraspherical{T,D<:Domain,R} = NormalizedPolynomialSpace{Ultraspherical{T,D,R},D,R}
+NormalizedUltraspherical(m) = NormalizedPolynomialSpace(Ultraspherical(m))
+NormalizedUltraspherical(m,d) = NormalizedPolynomialSpace(Ultraspherical(m,d))
+
+
+order(S::Ultraspherical) = S.order
+order(N::NormalizedPolynomialSpace{<:Ultraspherical}) = order(N.space)
+setdomain(S::Ultraspherical,d::Domain) = Ultraspherical(order(S),d)
+
+
+convert(::Type{Ultraspherical{T,D,R}}, S::Ultraspherical{T,D,R}) where {T,D,R} = S
+convert(::Type{Ultraspherical{A,D,R}}, S::Ultraspherical{B,D,R}) where {A,B,D,R} =
+    Ultraspherical{A,D,R}(convert(A, order(S)), domain(S))
+
+promote_rule(::Type{Ultraspherical{A,D,R}}, ::Type{Ultraspherical{B,D,R}}) where {A,B,D,R} =
+    Ultraspherical{promote_type(A,B),D,R}
+
+
+canonicalspace(S::Ultraspherical) = Chebyshev(domain(S))
+pointscompatible(A::Ultraspherical, B::Chebyshev) = domain(A) == domain(B)
+pointscompatible(A::Chebyshev, B::Ultraspherical) = domain(A) == domain(B)
+
+struct UltrasphericalPlan{CT,FT,IP}
+    chebplan::CT
+    cheb2ultraplan::FT
+
+    UltrasphericalPlan{CT,FT}(cp,c2lp,::Val{IP}) where {CT,FT,IP} = new{CT,FT,IP}(cp,c2lp)
+end
+
+struct UltrasphericalIPlan{CT,FT,IP}
+    chebiplan::CT
+    ultra2chebplan::FT
+
+    UltrasphericalIPlan{CT,FT}(cp,c2lp,::Val{IP}) where {CT,FT,IP} = new{CT,FT,IP}(cp,c2lp)
+end
+
+function UltrasphericalPlan(λ::Number,vals,inplace = Val(false))
+    cp = ApproxFunBase._plan_transform!!(inplace)(Chebyshev(),vals)
+    c2lp = plan_cheb2ultra(vals, λ)
+    UltrasphericalPlan{typeof(cp),typeof(c2lp)}(cp,c2lp,inplace)
+end
+
+function UltrasphericalIPlan(λ::Number,cfs,inplace = Val(false))
+    cp = ApproxFunBase._plan_itransform!!(inplace)(Chebyshev(),cfs)
+    l2cp = plan_ultra2cheb(cfs, λ)
+    UltrasphericalIPlan{typeof(cp),typeof(l2cp)}(cp,l2cp,inplace)
+end
+
+*(UP::UltrasphericalPlan{<:Any,<:Any,false},v::AbstractVector) =
+    UP.cheb2ultraplan*(UP.chebplan*v)
+*(UP::UltrasphericalIPlan{<:Any,<:Any,false},v::AbstractVector) =
+    UP.chebiplan*(UP.ultra2chebplan*v)
+
+*(UP::UltrasphericalPlan{<:Any,<:Any,true},v::AbstractVector) =
+    lmul!(UP.cheb2ultraplan, UP.chebplan*v)
+*(UP::UltrasphericalIPlan{<:Any,<:Any,true},v::AbstractVector) =
+    UP.chebiplan * lmul!(UP.ultra2chebplan, v)
+
+plan_transform(sp::Ultraspherical{Int},vals::AbstractVector) = CanonicalTransformPlan(sp,vals)
+plan_transform!(sp::Ultraspherical{Int},vals::AbstractVector) = CanonicalTransformPlan(sp,vals,Val(true))
+plan_transform(sp::Ultraspherical,vals::AbstractVector) = UltrasphericalPlan(order(sp),vals)
+plan_transform!(sp::Ultraspherical,vals::AbstractVector) = UltrasphericalPlan(order(sp),vals,Val(true))
+plan_itransform(sp::Ultraspherical{Int},cfs::AbstractVector) = ICanonicalTransformPlan(sp,cfs)
+plan_itransform!(sp::Ultraspherical{Int},cfs::AbstractVector) = ICanonicalTransformPlan(sp,cfs,Val(true))
+plan_itransform(sp::Ultraspherical,cfs::AbstractVector) = UltrasphericalIPlan(order(sp),cfs)
+plan_itransform!(sp::Ultraspherical,cfs::AbstractVector) = UltrasphericalIPlan(order(sp),cfs,Val(true))
+
+## Construction
+
+#domain(S) may be any domain
+
+ones(::Type{T},S::Ultraspherical) where {T<:Number} = Fun(S,fill(one(T),1))
+ones(S::Ultraspherical) = ones(Float64, S)
+
+
+
+## Fast evaluation
+
+function first(f::Fun{<:Ultraspherical{Int}})
+    n = length(f.coefficients)
+    n == 0 && return zero(cfstype(f))
+    n == 1 && return first(f.coefficients)
+    foldr(-,coefficients(f,Chebyshev))
+end
+
+last(f::Fun{<:Ultraspherical{Int}}) = reduce(+,coefficients(f,Chebyshev))
+
+first(f::Fun{<:Ultraspherical}) = f(leftendpoint(domain(f)))
+last(f::Fun{<:Ultraspherical}) = f(rightendpoint(domain(f)))
+
+function Fun(::typeof(identity), s::Ultraspherical)
+    d = domain(s)
+    m = order(s)
+    Fun(s, [mean(d), complexlength(d)/4m])
+end
+
+
+## Calculus
+
+
+
+
+spacescompatible(a::Ultraspherical,b::Ultraspherical) =
+    compare_orders(order(a), order(b)) && domainscompatible(a,b)
+hasfasttransform(::Ultraspherical) = true
+
+# these methods help with type-inference
+hasconversion(C::Chebyshev, U::Ultraspherical{<:Union{Int,StaticInt}}) = domainscompatible(C,U)
+hasconversion(U::Ultraspherical{<:Union{Int,StaticInt}}, C::Chebyshev) = false
+
+include("UltrasphericalOperators.jl")
+include("ultrasphericalconversions.jl")
+include("fastops.jl")

--- a/test/AFOP/Ultraspherical/UltrasphericalOperators.jl
+++ b/test/AFOP/Ultraspherical/UltrasphericalOperators.jl
@@ -1,0 +1,394 @@
+##  Jacobi Operator
+
+
+
+
+recA(::Type{T},S::Ultraspherical,k) where {T} = (2*(k+order(S)))/(k+one(T))   # one(T) ensures we get correct type
+recB(::Type{T},::Ultraspherical,_) where {T} = zero(T)
+recC(::Type{T},S::Ultraspherical,k) where {T} = (k-one(T)+2order(S))/(k+one(T))   # one(T) ensures we get correct type
+
+# x p_k
+recα(::Type{T},::Ultraspherical,_) where {T} = zero(T)
+recβ(::Type{T},S::Ultraspherical,k) where {T} = k/(2*(k-one(T)+order(S)))   # one(T) ensures we get correct type
+recγ(::Type{T},S::Ultraspherical,k) where {T} = (k-2+2order(S))/(2*(k-one(T)+order(S)))   # one(T) ensures we get correct type
+
+
+function normalization(::Type{T}, sp::Ultraspherical, k::Int) where T
+    λ = order(sp)
+    T(2)^(1-2λ)*π/((k+λ)*gamma(λ)^2*FastTransforms.Λ(real(T(k)),one(λ),2λ))
+end
+
+## Multiplication
+# these are special cases
+
+
+Base.stride(M::ConcreteMultiplication{<:Chebyshev,<:Ultraspherical}) =
+    stride(M.f)
+Base.stride(M::ConcreteMultiplication{<:Ultraspherical,<:Chebyshev}) =
+    stride(M.f)
+Base.stride(M::ConcreteMultiplication{<:Ultraspherical,<:Ultraspherical}) =
+    stride(M.f)
+
+@inline function _Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{<:Union{Integer,StaticInt}})
+    if order(sp) == 1
+        cfs = f.coefficients
+        MultiplicationWrapper(f,
+            SpaceOperator(
+                SymToeplitzOperator(cfs/2) +
+                    HankelOperator(view(cfs,3:length(cfs))/(-2)),
+                sp, sp)
+        )
+    else
+        ConcreteMultiplication(f,sp)
+    end
+end
+@static if VERSION >= v"1.8"
+    Base.@constprop aggressive Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{<:Union{Integer,StaticInt}}) =
+        _Multiplication(f, sp)
+else
+    Multiplication(f::Fun{<:Chebyshev}, sp::Ultraspherical{<:Union{Integer,StaticInt}}) = _Multiplication(f, sp)
+end
+
+
+## Derivative
+
+
+#Derivative(k::Integer,d::IntervalOrSegment)=Derivative(k-1:k,d)
+#Derivative(d::IntervalOrSegment)=Derivative(1,d)
+
+
+function Derivative(sp::Ultraspherical{LT,DD}, m::Number) where {LT,DD<:IntervalOrSegment}
+    assert_integer(m)
+    ConcreteDerivative(sp,m)
+end
+function Integral(sp::Ultraspherical{<:Any,<:IntervalOrSegment}, m::Number)
+    assert_integer(m)
+    λ = order(sp)
+    if m ≤ λ
+        ConcreteIntegral(sp,m)
+    else # Convert up
+        nsp = Ultraspherical(m,domain(sp))
+        Integralop = ConcreteIntegral(nsp,m)
+        C = Conversion(sp,nsp)
+        IntegralWrapper(Integralop * C, m, sp, rangespace(Integralop))
+    end
+end
+
+
+rangespace(D::ConcreteDerivative{<:Ultraspherical{LT,DD}}) where {LT,DD<:IntervalOrSegment} =
+    Ultraspherical(order(domainspace(D))+D.order,domain(D))
+
+bandwidths(D::ConcreteDerivative{<:Ultraspherical{LT,DD}}) where {LT,DD<:IntervalOrSegment} = -D.order,D.order
+bandwidths(D::ConcreteIntegral{<:Ultraspherical{LT,DD}}) where {LT,DD<:IntervalOrSegment} = D.order,-D.order
+Base.stride(D::ConcreteDerivative{<:Ultraspherical{LT,DD}}) where {LT,DD<:IntervalOrSegment} = D.order
+
+isdiag(D::ConcreteDerivative{<:Ultraspherical{<:Any,<:IntervalOrSegment}}) = false
+isdiag(D::ConcreteIntegral{<:Ultraspherical{<:Any,<:IntervalOrSegment}}) = false
+
+function getindex(D::ConcreteDerivative{<:Ultraspherical{TT,DD},K,T},
+               k::Integer,j::Integer) where {TT,DD<:IntervalOrSegment,K,T}
+    m=D.order
+    d=domain(D)
+    λ=order(domainspace(D))
+
+    if j==k+m
+        strictconvert(T,(pochhammer(one(T)*λ,m)*(4/complexlength(d)).^m))
+    else
+        zero(T)
+    end
+end
+
+
+## Integral
+
+linesum(f::Fun{<:Ultraspherical{LT,DD}}) where {LT,DD<:IntervalOrSegment} =
+    sum(setcanonicaldomain(f))*arclength(d)/2
+
+
+function rangespace(D::ConcreteIntegral{<:Ultraspherical{LT,DD}}) where {LT,DD<:IntervalOrSegment}
+    k = order(domainspace(D))-D.order
+    k == 0 ? Chebyshev(domain(D)) : Ultraspherical(k, domain(D))
+end
+
+function getindex(Q::ConcreteIntegral{<:Ultraspherical{LT,DD}},k::Integer,j::Integer) where {LT,DD<:IntervalOrSegment}
+    T=eltype(Q)
+    m=Q.order
+    d=domain(Q)
+    λ=order(domainspace(Q))
+    @assert m<=λ
+
+    if λ == 1 && k==j+1
+        C = complexlength(d)/2
+        strictconvert(T, C/(k-1))
+    elseif λ == m && k == j + m
+        C = complexlength(d)/2
+        U1toC = C/(k-1)
+        UmtoU1 = pochhammer(one(T)*λ,-(m-1))*(complexlength(d)/4)^(m-1)
+        strictconvert(T, U1toC * UmtoU1)
+    elseif λ > 1 && k==j+m
+        strictconvert(T,pochhammer(one(T)*λ,-m)*(complexlength(d)/4)^m)
+    else
+        zero(T)
+    end
+end
+
+
+
+## Conversion Operator
+
+function Conversion(A::Chebyshev, B::Ultraspherical)
+    @assert domain(A) == domain(B)
+    mB = order(B)
+    d=domain(A)
+    dB = domain(B)
+    if isequalhalf(mB) || mB == 1
+        return ConcreteConversion(A,B)
+    elseif (isinteger(mB) || isapproxhalfoddinteger(mB)) && mB > 0
+        r = mB:-1:(isinteger(mB) ? 2 : 1)
+        v = [ConcreteConversion(Ultraspherical(i-1, d), Ultraspherical(i,d)) for i in r]
+        U = domainspace(last(v))
+        CAU = ConcreteConversion(A, U)
+        v2 = Union{eltype(v), typeof(CAU)}[v; CAU]
+        bwsum = isapproxinteger(mB) ? (0, 2length(v2)) : (0,ℵ₀)
+        return ConversionWrapper(TimesOperator(v2, bwsum, (ℵ₀,ℵ₀), bwsum), A, B)
+    end
+    throw(ArgumentError("please implement $A → $B"))
+end
+
+function Conversion(A::Ultraspherical,B::Chebyshev)
+    @assert domain(A) == domain(B)
+    if isequalhalf(order(A)) && domain(A) == domain(B)
+        return ConcreteConversion(A,B)
+    end
+    throw(ArgumentError("please implement $A → $B"))
+end
+
+
+maxspace_rule(A::Ultraspherical,B::Chebyshev) = A
+
+
+function Conversion(A::Ultraspherical,B::Ultraspherical)
+    @assert domain(A) == domain(B)
+    a=order(A); b=order(B)
+    d=domain(A)
+    if b==a
+        return ConversionWrapper(Operator(I,A))
+    elseif isapproxinteger(b-a) || isapproxhalfoddinteger(b-a)
+        if -1 ≤ b-a ≤ 1 && (a,b) ≠ (2,1)
+            return ConcreteConversion(A,B)
+        elseif b-a > 1
+            r = b:-1:a+1
+            v = [ConcreteConversion(Ultraspherical(i-1,d), Ultraspherical(i,d)) for i in r]
+            if !(last(r) ≈ a+1)
+                vlast = ConcreteConversion(A, Ultraspherical(last(r)-1, d))
+                v2 = Union{eltype(v), typeof(vlast)}[v; vlast]
+            else
+                v2 = v
+            end
+            bwsum = isapproxinteger(b-a) ? (0, 2length(v)) : (0,ℵ₀)
+            return ConversionWrapper(TimesOperator(v2, bwsum, (ℵ₀,ℵ₀), bwsum), A, B)
+        end
+    end
+    throw(ArgumentError("please implement $A → $B"))
+end
+
+function maxspace_rule(A::Ultraspherical, B::Ultraspherical)
+    domainscompatible(A, B) || return NoSpace()
+    isapproxinteger(order(A) - order(B)) || return NoSpace()
+    order(A) > order(B) ? A : B
+end
+
+function getindex(M::ConcreteConversion{<:Chebyshev,U,T},
+        k::Integer,j::Integer) where {T, U<:Ultraspherical{<:Union{Integer, StaticInt}}}
+   # order must be 1
+    if k==j==1
+        one(T)
+    elseif k==j
+        one(T)/2
+    elseif j==k+2
+        -one(T)/2
+    else
+        zero(T)
+    end
+end
+
+
+function getindex(M::ConcreteConversion{U1,U2,T},
+        k::Integer,j::Integer) where {DD,RR,
+            U1<:Ultraspherical{<:Union{Integer, StaticInt},DD,RR},
+            U2<:Ultraspherical{<:Union{Integer, StaticInt},DD,RR},T}
+    #  we can assume that λ==m+1
+    λ=order(rangespace(M))
+    c=λ-one(T)  # this supports big types
+    if k==j
+        c/(k - 2 + λ)
+    elseif j==k+2
+        -c/(k + λ)
+    else
+        zero(T)
+    end
+end
+
+function getindex(M::ConcreteConversion{U1,U2,T},
+        k::Integer,j::Integer) where {DD,RR,
+            U1<:Ultraspherical{<:Any,DD,RR},
+            U2<:Ultraspherical{<:Any,DD,RR},T}
+    λ=order(rangespace(M))
+    if order(domainspace(M))+1==λ
+        c=λ-one(T)  # this supports big types
+        if k==j
+            c/(k - 2 + λ)
+        elseif j==k+2
+            -c/(k + λ)
+        else
+            zero(T)
+        end
+    else
+        error("Not implemented")
+    end
+end
+
+
+bandwidths(C::ConcreteConversion{<:Chebyshev,<:Ultraspherical{<:Union{Integer,StaticInt}}}) = 0,2  # order == 1
+bandwidths(C::ConcreteConversion{<:Ultraspherical{<:Union{Integer,StaticInt}},<:Ultraspherical{<:Union{Integer,StaticInt}}}) = 0,2
+
+function bandwidths(C::ConcreteConversion{<:Chebyshev,<:Ultraspherical})
+    orderone = order(rangespace(C)) == 1
+    orderone ? (0,2) : (0,ℵ₀)
+end
+function bandwidths(C::ConcreteConversion{<:Ultraspherical,<:Chebyshev})
+    orderone = order(domainspace(C)) == 1
+    orderone ? (0,2) : (0,ℵ₀)
+end
+
+function bandwidths(C::ConcreteConversion{<:Ultraspherical,<:Ultraspherical})
+    offbyone = order(domainspace(C))+1 == order(rangespace(C))
+    offbyone ? (0,2) : (0,ℵ₀)
+end
+
+Base.stride(C::ConcreteConversion{<:Chebyshev,<:Ultraspherical{<:Union{Integer,StaticInt}}}) = 2
+Base.stride(C::ConcreteConversion{<:Ultraspherical,<:Ultraspherical}) = 2
+
+isdiag(::ConcreteConversion{<:Chebyshev,<:Ultraspherical}) = false
+isdiag(::ConcreteConversion{<:Ultraspherical,<:Chebyshev}) = false
+isdiag(::ConcreteConversion{<:Ultraspherical,<:Ultraspherical}) = false
+
+## coefficients
+
+# return the space that has banded Conversion to the other
+function conversion_rule(a::Chebyshev,b::Ultraspherical{<:Union{Integer,StaticInt}})
+    if domainscompatible(a,b)
+        a
+    else
+        NoSpace()
+    end
+end
+
+conversion_rule(a::Ultraspherical{<:StaticInt}, b::Ultraspherical{<:StaticInt}) =
+    _conversion_rule(a, b)
+function conversion_rule(a::Ultraspherical{LT},b::Ultraspherical{LT}) where {LT}
+    _conversion_rule(a, b)
+end
+function _conversion_rule(a::Ultraspherical, b::Ultraspherical)
+    if domainscompatible(a,b) && isapproxinteger(order(a)-order(b))
+        order(a) < order(b) ? a : b
+    else
+        NoSpace()
+    end
+end
+
+# TODO: include in getindex to speed up
+function Integral(sp::Chebyshev{DD}, m::Number) where {DD<:IntervalOrSegment}
+    assert_integer(m)
+    usp = Ultraspherical(m,domain(sp))
+    I = Integral(usp,m)
+    C = Conversion(sp,usp)
+    T = TimesOperator(I, C)
+    IntegralWrapper(T, m, sp, sp)
+end
+
+
+
+## Non-banded conversions
+
+function getindex(M::ConcreteConversion{<:Chebyshev,<:Ultraspherical,T}, k::Integer,j::Integer) where {T}
+    λ = order(rangespace(M))
+    if λ == 1
+        if k==j==1
+            one(T)
+        elseif k==j
+            one(T)/2
+        elseif j==k+2
+            -one(T)/2
+        else
+            zero(T)
+        end
+    elseif λ == 0.5
+        # Cheb-to-Leg
+        if j==k==1
+            one(T)
+        elseif j==k
+            strictconvert(T,sqrt(π)/(2FastTransforms.Λ(k-1)))
+        elseif k < j && iseven(k-j)
+            strictconvert(T,-(j-1)*(k-0.5)*(FastTransforms.Λ((j-k-2)/2)/(j-k))*
+                            (FastTransforms.Λ((j+k-3)/2)/(j+k-1)))
+        else
+            zero(T)
+        end
+    else
+        error("Not implemented")
+    end
+end
+
+
+function getindex(M::ConcreteConversion{<:Ultraspherical,<:Chebyshev,T}, k::Integer,j::Integer) where {T}
+    λ = order(domainspace(M))
+    if λ == 1
+        # order must be 1
+        if k==j==1
+            one(T)
+        elseif k==j
+            one(T)/2
+        elseif j==k+2
+            -one(T)/2
+        else
+            zero(T)
+        end
+    elseif λ == 0.5
+        if k==1 && isodd(j)
+            strictconvert(T,FastTransforms.Λ((j-1)/2)^2/π)
+        elseif k ≤ j && iseven(k-j)
+            strictconvert(T,FastTransforms.Λ((j-k)/2)*FastTransforms.Λ((k+j-2)/2)*2/π)
+        else
+            zero(T)
+        end
+    else
+        error("Not implemented")
+    end
+end
+
+
+
+function getindex(M::ConcreteConversion{Ultraspherical{LT,DD,RR},
+                                     Ultraspherical{LT2,DD,RR},T},
+                     k::Integer,j::Integer) where {DD,RR,LT,LT2,T}
+    λ1 = order(domainspace(M))
+    λ2 = order(rangespace(M))
+    if abs(λ1-λ2) < 1
+        if j ≥ k && iseven(k-j)
+            strictconvert(T,(λ1 < λ2 && k ≠ j ? -1 : 1) *  # fix sign for lgamma
+                exp(lgamma(λ2)+log(k-1+λ2)-lgamma(λ1)-lgamma(λ1-λ2) + lgamma((j-k)/2+λ1-λ2)-
+                lgamma((j-k)/2+1)+lgamma((k+j-2)/2+λ1)-lgamma((k+j-2)/2+λ2+1)))
+        else
+            zero(T)
+        end
+    else
+        error("Not implemented")
+    end
+end
+
+
+ReverseOrientation(S::Ultraspherical) = ReverseOrientationWrapper(NegateEven(S,reverseorientation(S)))
+Reverse(S::Ultraspherical) = ReverseWrapper(NegateEven(S,S))
+
+Evaluation(S::MaybeNormalized{<:Ultraspherical},x::Number,o::Integer) = ConcreteEvaluation(S,x,o)

--- a/test/AFOP/Ultraspherical/fastops.jl
+++ b/test/AFOP/Ultraspherical/fastops.jl
@@ -1,0 +1,112 @@
+###
+# This file contains BLAS/BandedMatrix overrides for operators
+# that depend on the structure of BandedMatrix
+####
+
+
+
+
+#####
+# Conversions
+#####
+
+function BandedMatrix(S::SubOperator{T,ConcreteConversion{Chebyshev{DD,RR},
+                Ultraspherical{LT,DD,RR},T},
+            NTuple{2,UnitRange{Int}}}) where {T,LT<:Union{Integer, StaticInt},DD,RR}
+    # we can assume order is 1
+    ret = BandedMatrix{eltype(S)}(undef, size(S), bandwidths(S))
+    kr,jr = parentindices(S)
+    dg = diagindshift(S)
+
+    @assert -bandwidth(ret,1) ≤ dg ≤ bandwidth(ret,2)-2
+
+    ret[band(dg)] .= 0.5
+    ret[band(dg+1)] .= 0.0
+    ret[band(dg+2)] .= -0.5
+
+    # correct first entry
+    if 1 in kr && 1 in jr
+        ret[1,1] = 1.0
+    end
+
+    ret
+end
+
+function BandedMatrix(V::SubOperator{T,ConcreteConversion{Ultraspherical{LT1,DD,RR},Ultraspherical{LT2,DD,RR},T},
+                                                                  NTuple{2,UnitRange{Int}}}) where {T,LT1,LT2,DD,RR}
+
+    n,m = size(V)
+    V_l, V_u = bandwidths(V)
+    ret = BandedMatrix{eltype(V)}(undef, (n,m), (V_l,V_u))
+    kr,jr = parentindices(V)
+
+    (isempty(kr) || isempty(jr)) && return ret
+
+    dg = diagindshift(V)
+
+
+    λ = order(rangespace(parent(V)))
+    c = λ-one(T)
+
+    # need to drop columns
+
+
+
+    1-n ≤ dg ≤ m-1 && (ret[band(dg)] .= c./(jr[max(0,dg)+1:min(n+dg,m)] .- 2 .+ λ))
+    1-n ≤ dg+1 ≤ m-1 && (ret[band(dg+1)] .= 0)
+    1-n ≤ dg+2 ≤ m-1 && (ret[band(dg+2)] .= c./(2 .- λ .- jr[max(0,dg+2)+1:min(n+dg+2,m)]))
+
+    ret
+end
+
+
+#####
+# Derivatives
+#####
+
+
+
+function BandedMatrix(S::SubOperator{T,ConcreteDerivative{Chebyshev{DD,RR},K,T},
+                                                     NTuple{2,UnitRange{Int}}}) where {T,K,DD,RR}
+
+    n,m = size(S)
+    ret = BandedMatrix{eltype(S)}(undef, (n,m), bandwidths(S))
+    kr,jr = parentindices(S)
+    dg = diagindshift(S)
+
+    D = parent(S)
+    k = D.order
+    d = domain(D)
+
+    C=strictconvert(T,pochhammer(one(T),k-1)/2*(4/(complexlength(d)))^k)
+
+
+    # need to drop columns
+
+
+    if 1-n ≤ dg+k ≤ m-1
+        ret[band(dg+k)] .= C.*(jr[max(0,dg+k)+1:min(n+dg+k,m)] .- one(T))
+    end
+
+    ret
+end
+
+
+function BandedMatrix(S::SubOperator{T,ConcreteDerivative{Ultraspherical{LT,DD,RR},K,T},
+                                                  NTuple{2,UnitRange{Int}}}) where {T,K,DD,RR,LT}
+    n,m = size(S)
+    ret = BandedMatrix{eltype(S)}(undef, (n,m), bandwidths(S))
+    kr,jr = parentindices(S)
+    dg = diagindshift(S)
+
+    D = parent(S)
+    k = D.order
+    λ = order(domainspace(D))
+    d = domain(D)
+
+    C = strictconvert(T,pochhammer(one(T)*λ,k)*(4/(complexlength(d)))^k)
+    ret[band(dg+k)] .= C
+
+    ret
+end
+

--- a/test/AFOP/Ultraspherical/ultrasphericalconversions.jl
+++ b/test/AFOP/Ultraspherical/ultrasphericalconversions.jl
@@ -1,0 +1,149 @@
+export ultraconversion!,ultraint!
+
+## Start of support for UFun
+
+# diff from T -> U
+function ultradiff(v::AbstractVector{T}) where T<:Number
+    #polynomial is p(x) = sum ( v[i] * x^(i-1) )
+    if length(v)≤1
+        w = zeros(T,1)
+    else
+        w = Array{T}(undef, length(v)-1)
+        for k=1:length(v)-1
+            @inbounds w[k] = k*v[k+1]
+        end
+    end
+
+    w
+end
+
+#int from U ->T
+
+#TODO: what about missing truncation?
+function ultraint!(v::AbstractMatrix{T}) where T<:Number
+    for k=size(v,1):-1:2
+        for j=1:size(v,2)
+            @inbounds v[k,j] = v[k-1,j]/(k-1)
+        end
+    end
+
+    @simd for j=1:size(v)[2]
+        @inbounds v[1,j] = zero(T)
+    end
+
+    v
+end
+
+function ultraint!(v::AbstractVector{T}) where T<:Number
+    resize!(v,length(v)+1)
+    @simd for k=length(v):-1:2
+        @inbounds v[k] = v[k-1]/(k-1)
+    end
+
+    @inbounds v[1] = zero(T)
+
+    v
+end
+
+# Convert from U -> T
+function ultraiconversion(v::AbstractVector{T}) where T<:Number
+    n = length(v)
+    w = Array{T}(undef, n)
+
+    if n == 1
+        w[1] = v[1]
+    elseif n == 2
+        w[1] = v[1]
+        w[2] = 2v[2]
+    elseif n ≥ 3
+        @inbounds w[end] = 2v[end]
+        @inbounds w[end-1] = 2v[end-1]
+
+        for k = n-2:-1:2
+            @inbounds w[k] = 2*(v[k] + .5w[k+2])
+        end
+
+        @inbounds w[1] = v[1] + .5w[3]
+    end
+
+    w
+end
+
+
+# Convert T -> U
+function ultraconversion(v::AbstractVector{T}) where T<:Number
+    n = length(v)
+    w = Array{T}(undef, n)
+
+    if n == 1
+        w[1] = v[1]
+    elseif n == 2
+        w[1] = v[1]
+        w[2] = .5v[2]
+    elseif n ≥ 3
+        w[1] = v[1] - .5v[3]
+
+        @simd for j=2:n-2
+            @inbounds w[j] = .5*(v[j] - v[j+2])
+        end
+
+        w[n-1] = .5v[n-1]
+        w[n] = .5v[n]
+    end
+
+    w
+end
+
+function ultraconversion!(v::AbstractVector{T}) where T<:Number
+    n = length(v) #number of coefficients
+
+    if n ≤ 1
+        #do nothing
+    elseif n == 2
+        @inbounds v[2] /= 2
+    else
+        @inbounds v[1] -= v[3]/2
+
+        for j=2:n-2
+            @inbounds v[j] = (v[j] - v[j+2])/2
+        end
+        @inbounds v[n-1] /= 2
+        @inbounds v[n] /= 2
+    end
+
+    v
+end
+
+function ultraconversion!(v::AbstractMatrix{T}) where T<:Number
+    n = size(v)[1] #number of coefficients
+    m = size(v)[2] #number of funs
+
+
+    if n ≤ 1
+        #do nothing
+    elseif n == 2
+        @simd for k=1:m
+            @inbounds v[2,k] /= 2
+        end
+    else
+        for k=1:m
+            @inbounds v[1,k] -= v[3,k]/2
+
+            for j=2:n-2
+                @inbounds v[j,k] = (v[j,k] - v[j+2,k])/2
+            end
+            @inbounds v[n-1,k] /= 2
+            v[n,k] /= 2
+        end
+    end
+
+    v
+end
+
+
+#ultraiconversion and ultraconversion are linear, so it is possible to define them on Complex numbers as so
+#ultraiconversion(v::AbstractVector{Complex{Float64}})=ultraiconversion(real(v)) + ultraiconversion(imag(v))*1.0im
+#ultraconversion(v::AbstractVector{Complex{Float64}})=ultraconversion(real(v)) + ultraconversion(imag(v))*1.0im
+
+#using DualNumbers
+#ultraconversion{T<:Number}(v::AbstractVector{Dual{T}})=dual(ultraconversion(real(v)), ultraconversion(epsilon(v)) )

--- a/test/PolynomialSpacesTests.jl
+++ b/test/PolynomialSpacesTests.jl
@@ -1,0 +1,372 @@
+module MiscApproxFunBaseTests
+
+using ApproxFunBase
+using Test
+using LinearAlgebra
+using StaticArrays
+using BandedMatrices
+
+using IntervalSets: AbstractInterval
+import IntervalSets: endpoints, closedendpoints
+
+include("AFOP/PolynomialSpaces.jl")
+using .PolynomialSpaces
+
+struct UniqueInterval{T, I<:AbstractInterval{T}} <: AbstractInterval{T}
+    parentinterval :: I
+end
+
+for f in [:endpoints, :closedendpoints]
+    @eval $f(m::UniqueInterval) = $f(m.parentinterval)
+end
+
+Base.in(x, m::UniqueInterval) = in(x, m.parentinterval)
+Base.isempty(m::UniqueInterval) = isempty(m.parentinterval)
+
+ApproxFunBase.domainscompatible(a::UniqueInterval, b::UniqueInterval) = a == b
+
+Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == b.parentinterval; true)
+
+@testset "ApproxFunBase" begin
+    @testset "Constructor" begin
+        @test (@inferred Fun()) == Fun(x->x, Chebyshev())
+        @test (@inferred norm(Fun())) ≈ norm(Fun(), 2) ≈ √(2/3) # √∫x^2 dx over -1..1
+    end
+
+    @testset "transform" begin
+        v = rand(4)
+        v2 = transform(NormalizedChebyshev(), v)
+        @test itransform(NormalizedChebyshev(), v2) ≈ v
+
+        @testset "coefficients" begin
+            f = @inferred Fun(x->x^2, Chebyshev())
+            v = @inferred coefficients(f, Chebyshev(), Legendre())
+            @test eltype(v) == eltype(coefficients(f))
+            @test v ≈ coefficients(Fun(x->x^2, Legendre()))
+
+            # inference check for coefficients
+            v = @inferred coefficients(Float64[0,0,1], Chebyshev(), Ultraspherical(1))
+            @test v ≈ [-0.5, 0, 0.5]
+        end
+    end
+
+    @testset "multiplication inference" begin
+        function g2()
+           f = Fun(0..1)
+           f * f
+        end
+        y = @inferred g2()(0.1)
+        @test y ≈ (0.1)^2
+
+        function g3()
+           f = Fun(0..1)
+           f * f * f
+        end
+        y = @inferred g3()(0.1)
+        @test y  ≈ (0.1)^3
+
+        function g4()
+           f = Fun(0..1)
+           f * f * f * f
+        end
+        y = @inferred g4()(0.1)
+        @test y ≈ (0.1)^4
+    end
+
+    @testset "intpow" begin
+        @testset "Interval" begin
+            function h(::Val{N}) where {N}
+               f = Fun(0..1)
+               f^N
+            end
+            @test (@inferred h(Val(0)))(0.1) ≈ (0.1)^0
+            @test (@inferred h(Val(1)))(0.1) ≈ (0.1)^1
+            @test (@inferred h(Val(2)))(0.1) ≈ (0.1)^2
+            @test (@inferred h(Val(3)))(0.1) ≈ (0.1)^3
+            @test (@inferred h(Val(4)))(0.1) ≈ (0.1)^4
+            @test h(Val(10))(0.1) ≈ (0.1)^10 rtol=1e-6
+        end
+
+        @testset "ChebyshevInterval" begin
+            function h(::Val{N}) where {N}
+               f = Fun()
+               f^N
+            end
+            @test (@inferred h(Val(0)))(0.1) ≈ (0.1)^0
+            @test (@inferred h(Val(1)))(0.1) ≈ (0.1)^1
+            @test (@inferred h(Val(2)))(0.1) ≈ (0.1)^2
+            @test (@inferred h(Val(3)))(0.1) ≈ (0.1)^3
+            @test (@inferred h(Val(4)))(0.1) ≈ (0.1)^4
+            @test h(Val(10))(0.1) ≈ (0.1)^10 rtol=1e-6
+        end
+
+        @testset "UniqueInterval" begin
+            f = Fun(UniqueInterval(0..1))
+            g = @inferred f^0
+            @test coefficients(g) == coefficients(one(Fun(0..1)))
+            g = @inferred f^1
+            @test coefficients(g) == coefficients(Fun(0..1)^1)
+            g = @inferred f^2
+            @test coefficients(g) == coefficients(Fun(0..1)^2)
+            g = @inferred f*f
+            @test coefficients(g) == coefficients(Fun(0..1)^2)
+            g = @inferred f^3
+            @test coefficients(g) == coefficients(Fun(0..1)^3)
+            g = @inferred f*f*f
+            @test coefficients(g) == coefficients(Fun(0..1)^3)
+            g = @inferred f^4
+            @test coefficients(g) == coefficients(Fun(0..1)^4)
+            g = @inferred f*f*f*f
+            @test coefficients(g) == coefficients(Fun(0..1)^4)
+        end
+    end
+
+    @testset "int coeffs" begin
+        f = Fun(Chebyshev(), [0,1])
+        @test f(0.4) ≈ 0.4
+        f = Fun(NormalizedChebyshev(), [0,1])
+        @test f(0.4) ≈ 0.4 * √(2/pi)
+
+        f = Fun(Chebyshev(), [1])
+        @test f(0.4) ≈ 1
+        f = Fun(NormalizedChebyshev(), [1])
+        @test f(0.4) ≈ √(1/pi)
+    end
+
+    @testset "pad" begin
+        @testset "Fun" begin
+            f = Fun()
+            zf = zero(f)
+            @test (@inferred pad([f], 3)) == [f, zf, zf]
+            @test (@inferred pad([f, zf], 1)) == [f]
+            v = [f, zf]
+            @test @inferred pad!(v, 1) == [f]
+            @test length(v) == 1
+        end
+    end
+
+    @testset "conversion" begin
+        C12 = Conversion(Chebyshev(), NormalizedLegendre())
+        C21 = Conversion(NormalizedLegendre(), Chebyshev())
+        @test Matrix((C12 * C21)[1:10, 1:10]) ≈ I
+        @test Matrix((C21 * C12)[1:10, 1:10]) ≈ I
+
+        C12 = Conversion(Chebyshev(), NormalizedPolynomialSpace(Ultraspherical(1)))
+        C1C2 = Conversion(Ultraspherical(1), NormalizedPolynomialSpace(Ultraspherical(1))) *
+                Conversion(Chebyshev(), Ultraspherical(1))
+        @test Matrix(C12[1:10, 1:10]) ≈ Matrix(C1C2[1:10, 1:10])
+    end
+
+    @testset "union" begin
+        @test union(Chebyshev(), NormalizedLegendre()) == Jacobi(Chebyshev())
+        @test union(Chebyshev(), Legendre()) == Jacobi(Chebyshev())
+    end
+
+    @testset "Fun constructor" begin
+        # we make the fun go through somewhat complicated chains of functions
+        # that break inference of the space
+        # however, the type of coefficients should be inferred correctly.
+        f = Fun(Chebyshev(0..1))
+        newfc(f) = coefficients(Fun(Fun(f, Legendre(0..1)), space(f)))
+        newvals(f) = values(Fun(Fun(f, Legendre(0..1)), space(f)))
+        @test newfc(f) ≈ coefficients(f)
+        @test newvals(f) ≈ values(f)
+
+        newfc2(f) = coefficients(chop(pad(f, 10)))
+        @test newfc2(f) == coefficients(f)
+
+        f2 = Fun(space(f), view(Float64[1:4;], :))
+        f3 = Fun(space(f), Float64[1:4;])
+        @test newvals(f2) ≈ values(f3)
+        @test values(f2) ≈ values(f3)
+
+        # Ensure no trailing zeros
+        f = Fun(Ultraspherical(0.5, 0..1))
+        cf = coefficients(f)
+        @test findlast(!iszero, cf) == length(cf)
+
+        @testset "OneHotVector" begin
+            for n in [1, 3, 10_000]
+                f = Fun(Chebyshev(), [zeros(n-1); 1])
+                g = ApproxFunBase.basisfunction(Chebyshev(), n)
+                @test f == g
+                @test f(0.5) == g(0.5)
+            end
+        end
+    end
+
+    @testset "multiplication of Funs" begin
+        f = Fun(Chebyshev(), Float64[1:101;])
+        g = Fun(Chebyshev(), Float64[1:101;]*im)
+        @test f(0.5)*g(0.5) ≈ (f*g)(0.5)
+    end
+
+    @testset "Multivariate" begin
+        @testset for S in Any[Chebyshev(), Legendre()]
+            f = Fun(x->ones(2,2), S)
+            @test (f+1) * f ≈ (1+f) * f ≈ f^2 + f
+            @test (f-1) * f ≈ f^2 - f
+            @test (1-f) * f ≈ f - f^2
+            @test f + f ≈ 2f ≈ f*2
+        end
+    end
+
+    @testset "static coeffs" begin
+        f = Fun(Chebyshev(), SA[1,2,3])
+        g = Fun(Chebyshev(), [1,2,3])
+        @test coefficients(f^2) == coefficients(g^2)
+    end
+
+    @testset "special functions" begin
+        for f in Any[Fun(), Fun(-0.5..1), Fun(Segment(1.0+im,2.0+2im))]
+            for spfn in Any[sin, cos, exp]
+                p = leftendpoint(domain(f))
+                @test spfn(f)(p) ≈ spfn(p) atol=1e-14
+            end
+        end
+    end
+
+    @testset "Derivative" begin
+        @test Derivative() == Derivative()
+        for d in Any[(), (0..1,)]
+            for ST in Any[Chebyshev, Legendre,
+                    (x...) -> Jacobi(2,2,x...), (x...) -> Jacobi(1.5,2.5,x...)]
+                S1 = ST(d...)
+                for S in [S1, NormalizedPolynomialSpace(S1)]
+                    @test Derivative(S) == Derivative(S,1)
+                    @test Derivative(S)^2 == Derivative(S,2)
+                    f = Fun(x->x^3, S)
+                    @test Derivative(S) * f ≈ Fun(x->3x^2, S)
+                    @test Derivative(S,2) * f ≈ Fun(x->6x, S)
+                    @test Derivative(S,3) * f ≈ Fun(x->6, S)
+                    @test Derivative(S,4) * f ≈ zeros(S)
+                end
+            end
+        end
+        @test Derivative(Chebyshev()) != Derivative(Chebyshev(), 2)
+        @test Derivative(Chebyshev()) != Derivative(Legendre())
+    end
+
+    @testset "SubOperator" begin
+        D = Derivative(Chebyshev())
+        S = @view D[1:10, 1:10]
+        @test rowrange(S, 1) == 2:2
+        @test colrange(S, 2) == 1:1
+        @test (@inferred BandedMatrix(S)) == (@inferred Matrix(S))
+
+        A = Derivative() * Multiplication(Fun()) : Chebyshev();
+        kr = 1:ApproxFunBase.InfiniteCardinal{0}()
+        B1 = A[kr, :][1:10, 1:10]
+        B2 = A[:, kr][1:10, 1:10]
+        B3 = A[:, :][1:10, 1:10]
+        B4 = A[kr, kr][1:10, 1:10]
+        @test B1 == B2 == B3 == B4
+    end
+
+    @testset "CachedOperator" begin
+        C = cache(Derivative())
+        C = C : Chebyshev() → Ultraspherical(2)
+        D = Derivative() : Chebyshev() → Ultraspherical(2)
+        @test C[1:2, 1:0] == D[1:2, 1:0]
+        @test C[1:10, 1:10] == D[1:10, 1:10]
+        for col in 1:5, row in 1:5
+            @test C[row, col] == D[row, col]
+        end
+    end
+
+    @testset "PartialInverseOperator" begin
+        @testset "sanity check" begin
+            A = UpperTriangular(rand(10, 10))
+            B = inv(A)
+            for I in CartesianIndices(B)
+                @test B[I] ≈ ApproxFunBase._getindexinv(A, Tuple(I)..., UpperTriangular)
+            end
+        end
+        C = Conversion(Chebyshev(), Ultraspherical(1))
+        P = PartialInverseOperator(C, (0, 6))
+        Iapprox = (P * C)[1:10, 1:10]
+        @test all(isone, diag(Iapprox))
+        for k in axes(Iapprox,1), j in k + 1:min(k + bandwidth(P,2), size(Iapprox, 2))
+            @test Iapprox[k,j] ≈ 0 atol=eps(eltype(Iapprox))
+        end
+        B = AbstractMatrix(P[1:10, 1:10])
+        @testset for I in CartesianIndices(B)
+            @test B[I] ≈ P[Tuple(I)...] rtol=1e-8 atol=eps(eltype(B))
+        end
+    end
+
+    @testset "istriu/istril" begin
+        for D in Any[Derivative(Chebyshev()),
+                Conversion(Chebyshev(), Legendre()),
+                Multiplication(Fun(Chebyshev()), Chebyshev())]
+            D2 = D[1:3, 1:3]
+            for f in Any[istriu, istril]
+                @test f(D) == f(D2)
+                @test f(D') == f(D2')
+            end
+        end
+    end
+
+    @testset "inplace ldiv" begin
+        @testset for T in [Float32, Float64, ComplexF32, ComplexF64]
+            v = rand(T, 4)
+            v2 = copy(v)
+            ApproxFunBase.ldiv_coefficients!(Conversion(Chebyshev(), Ultraspherical(1)), v)
+            @test ApproxFunBase.ldiv_coefficients(Conversion(Chebyshev(), Ultraspherical(1)), v2) ≈ v
+        end
+    end
+
+    @testset "specialfunctionnormalizationpoint" begin
+        a = @inferred ApproxFunBase.specialfunctionnormalizationpoint(exp,real,Fun())
+        @test a[1] == 1
+        @test a[2] ≈ exp(1)
+    end
+
+    @testset "ArraySpace" begin
+        f = Fun(x->[cos(x), exp(x)], -1..1)
+        for x in [-1,0,1]
+            @test (f + one(f))(x) ≈ f(x) .+ one.(f(x))
+        end
+    end
+
+    @testset "Bivariate" begin
+        f = (x,y)->x^2 * y^3
+        P = ProductFun(f, Chebyshev()⊗Chebyshev())
+        x = 0.2; y = 0.3;
+        @test P(x, y) ≈ f(x,y)
+
+        @test (P * one(P))(x,y) ≈ P(x,y)
+        @test (P + zero(P))(x,y) ≈ P(x,y)
+
+        # coefficients copied from P above
+        coeffs = SVector{4}(zeros(3), [0.375, 0, 0.375], zeros(3), [0.125, 0, 0.125])
+        fv = [Fun(Chebyshev(), c) for c in coeffs]
+        P2 = @inferred ProductFun(fv, Chebyshev())
+        @test P2(x, y) ≈ f(x, y)
+
+        L = LowRankFun(f, Chebyshev()⊗Chebyshev())
+        @test (@inferred L * P)(x, y) ≈ (@inferred P * L)(x, y) ≈ f(x,y)^2
+
+        @test (L^0 * L)(x,y) ≈ L(x,y)
+        @test (@inferred((L -> L^1)(L)))(x,y) ≈ L(x,y)
+        @test (@inferred((L -> L^2)(L)))(x,y) ≈ (L*L)(x,y)
+        @test (@inferred((L -> L^4)(L)))(x,y) ≈ (L*L*L*L)(x,y)
+        @test (L * one(L))(x,y) ≈ L(x,y)
+        @test (L + zero(L))(x,y) ≈ L(x,y)
+    end
+
+    @testset "Multiplication" begin
+        # empty coefficients
+        f = () -> Multiplication(Fun(Chebyshev(), Float64[]), Ultraspherical(1))
+        M = VERSION >= v"1.8" ? (@inferred f()) : f()
+        @test all(iszero, coefficients(M * Fun()))
+    end
+
+    @testset "TimesOperator" begin
+        x = Fun()
+        A = @inferred Derivative() * Multiplication(x, Chebyshev())
+        @test A * x ≈ 2x
+    end
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -727,3 +727,5 @@ end
 
 @time include("ETDRK4Test.jl")
 include("show.jl")
+
+include("PolynomialSpacesTests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -696,7 +696,11 @@ end
     @test eltype(vs) == Int
 
     v = ApproxFunBase.CachedIterator(1:∞)
-    @test Base.IteratorSize(v) == Base.IsInfinite()
+    if Base.IteratorSize(1:∞) isa Base.IsInfinite
+        @test Base.IteratorSize(v) == Base.IsInfinite()
+    else # on older versions of InfiniteArrays
+        @test Base.IteratorSize(v) == Base.HasLength()
+    end
     @test isinf(length(v))
     @test eltype(v) == Int
     @test findfirst(3, v) == 3


### PR DESCRIPTION
This copies over some of the Polynomial space functionality from `ApproxFunOrthogonalPolynomials`, which makes adding tests easier for this package.