### PR TITLE
Kron for Fun and UniformScaling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.39"
+version = "0.8.40"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/Multivariate.jl
+++ b/src/Multivariate/Multivariate.jl
@@ -110,3 +110,5 @@ function Base.kron(f::Fun,g::Fun)
 end
 Base.kron(f::Fun,g::Number) = kron(f,Fun(g))
 Base.kron(f::Number,g::Fun) = kron(Fun(f),g)
+Base.kron(f::Fun,g::UniformScaling) = kron(f,Operator(g))
+Base.kron(f::UniformScaling,g::Fun) = kron(Operator(f),g)

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -223,27 +223,21 @@ end
 
 ## Shorthand
 
+
 ⊗(A,B) = kron(A,B)
 
 Base.kron(A::Operator,B::Operator) = KroneckerOperator(A,B)
 Base.kron(A::Operator,B) = KroneckerOperator(A,B)
 Base.kron(A,B::Operator) = KroneckerOperator(A,B)
-
-function Base.kron(A::AbstractVector{T},B::Operator) where {T<:Operator}
+Base.kron(A::AbstractVector{T},B::Operator) where {T<:Operator} =
     Operator{promote_type(eltype(T),eltype(B))}[kron(a,B) for a in A]
-end
-
-function Base.kron(A::Operator,B::AbstractVector{T}) where {T<:Operator}
+Base.kron(A::Operator,B::AbstractVector{T}) where {T<:Operator} =
     Operator{promote_type(eltype(T),eltype(A))}[kron(A,b) for b in B]
-end
-
-function Base.kron(A::AbstractVector{T},B::UniformScaling) where {T<:Operator}
+Base.kron(A::AbstractVector{T},B::UniformScaling) where {T<:Operator} =
     Operator{promote_type(eltype(T),eltype(B))}[kron(a,1.0B) for a in A]
-end
-
-function Base.kron(A::UniformScaling,B::AbstractVector{T}) where {T<:Operator}
+Base.kron(A::UniformScaling,B::AbstractVector{T}) where {T<:Operator} =
     Operator{promote_type(eltype(T),eltype(A))}[kron(1.0A,b) for b in B]
-end
+
 
 
 

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -223,21 +223,32 @@ end
 
 ## Shorthand
 
-
-⊗(A,B) = kron(A,B)
+const KronTypes = Union{Fun, Operator, AbstractArray{<:Operator}}
+const MiscKronTypes = Union{Number, UniformScaling}
+# avoid defining methods like 2 ⊗ 2
+⊗(A::KronTypes, B::KronTypes) = kron(A, B)
+⊗(A::KronTypes, B::MiscKronTypes) = kron(A, B)
+⊗(A::MiscKronTypes, B::KronTypes) = kron(A, B)
 
 Base.kron(A::Operator,B::Operator) = KroneckerOperator(A,B)
 Base.kron(A::Operator,B) = KroneckerOperator(A,B)
 Base.kron(A,B::Operator) = KroneckerOperator(A,B)
-Base.kron(A::AbstractVector{T},B::Operator) where {T<:Operator} =
-    Operator{promote_type(eltype(T),eltype(B))}[kron(a,B) for a in A]
-Base.kron(A::Operator,B::AbstractVector{T}) where {T<:Operator} =
-    Operator{promote_type(eltype(T),eltype(A))}[kron(A,b) for b in B]
-Base.kron(A::AbstractVector{T},B::UniformScaling) where {T<:Operator} =
-    Operator{promote_type(eltype(T),eltype(B))}[kron(a,1.0B) for a in A]
-Base.kron(A::UniformScaling,B::AbstractVector{T}) where {T<:Operator} =
-    Operator{promote_type(eltype(T),eltype(A))}[kron(1.0A,b) for b in B]
 
+function Base.kron(A::AbstractVector{T},B::Operator) where {T<:Operator}
+    Operator{promote_type(eltype(T),eltype(B))}[kron(a,B) for a in A]
+end
+
+function Base.kron(A::Operator,B::AbstractVector{T}) where {T<:Operator}
+    Operator{promote_type(eltype(T),eltype(A))}[kron(A,b) for b in B]
+end
+
+function Base.kron(A::AbstractVector{T},B::UniformScaling) where {T<:Operator}
+    Operator{promote_type(eltype(T),eltype(B))}[kron(a,1.0B) for a in A]
+end
+
+function Base.kron(A::UniformScaling,B::AbstractVector{T}) where {T<:Operator}
+    Operator{promote_type(eltype(T),eltype(A))}[kron(1.0A,b) for b in B]
+end
 
 
 

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -223,12 +223,7 @@ end
 
 ## Shorthand
 
-const KronTypes = Union{Fun, Operator, AbstractArray{<:Operator}}
-const MiscKronTypes = Union{Number, UniformScaling}
-# avoid defining methods like 2 ⊗ 2
-⊗(A::KronTypes, B::KronTypes) = kron(A, B)
-⊗(A::KronTypes, B::MiscKronTypes) = kron(A, B)
-⊗(A::MiscKronTypes, B::KronTypes) = kron(A, B)
+⊗(A,B) = kron(A,B)
 
 Base.kron(A::Operator,B::Operator) = KroneckerOperator(A,B)
 Base.kron(A::Operator,B) = KroneckerOperator(A,B)

--- a/test/PolynomialSpacesTests.jl
+++ b/test/PolynomialSpacesTests.jl
@@ -218,6 +218,8 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
             x = Fun()
             O = x ⊗ I
             @test O * Fun((x,y)->x^2 * y^2, Chebyshev()^2) ≈ Fun((x,y)->x^3 * y^2, Chebyshev()^2)
+            O = I ⊗ x
+            @test O * Fun((x,y)->x^2 * y^2, Chebyshev()^2) ≈ Fun((x,y)->x^2 * y^3, Chebyshev()^2)
         end
     end
 

--- a/test/PolynomialSpacesTests.jl
+++ b/test/PolynomialSpacesTests.jl
@@ -203,13 +203,21 @@ Base.:(==)(a::UniqueInterval, b::UniqueInterval) = (@assert a.parentinterval == 
         @test f(0.5)*g(0.5) ≈ (f*g)(0.5)
     end
 
-    @testset "Multivariate" begin
+    @testset "ArraySpace" begin
         @testset for S in Any[Chebyshev(), Legendre()]
             f = Fun(x->ones(2,2), S)
             @test (f+1) * f ≈ (1+f) * f ≈ f^2 + f
             @test (f-1) * f ≈ f^2 - f
             @test (1-f) * f ≈ f - f^2
             @test f + f ≈ 2f ≈ f*2
+        end
+    end
+
+    @testset "Multivariate" begin
+        @testset "kron" begin
+            x = Fun()
+            O = x ⊗ I
+            @test O * Fun((x,y)->x^2 * y^2, Chebyshev()^2) ≈ Fun((x,y)->x^3 * y^2, Chebyshev()^2)
         end
     end
 


### PR DESCRIPTION
After this,
```julia
julia> Fun() ⊗ I
KroneckerOperator : ApproxFunBase.UnsetSpace() ⊗ ApproxFunBase.UnsetSpace() → ApproxFunBase.UnsetSpace() ⊗ ApproxFunBase.UnsetSpace()
```
The `I` is promoted to an operator automatically.