### PR TITLE
Faster iterate method for TrivialInterlacer

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,22 @@ end
 
         @test collect(ApproxFunBase.BlockInterlacer(([2],[2],[2]))) ==
             [(1,1),(1,2),(2,1),(2,2),(3,1),(3,2)]
+
+        @testset "TrivialInterlacer" begin
+            o = Ones{Int}(ℵ₀)
+            f = Fill(1, ℵ₀)
+            function test_nD(nD)
+                B1 = ApproxFunBase.BlockInterlacer(ntuple(_->o, nD))
+                B2 = ApproxFunBase.BlockInterlacer(ntuple(_->f, nD))
+                it = Iterators.take(zip(B1, B2), 100_000)
+                for (a,b) in it
+                    @test a == b
+                end
+            end
+            test_nD(1)
+            test_nD(2)
+            test_nD(3)
+        end
     end
 
     @testset "issue #94" begin


### PR DESCRIPTION
On master,
```julia
julia> o = Ones{Int}(ℵ₀)
ℵ₀-element Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf()

julia> B = ApproxFunBase.BlockInterlacer((o, o))
ApproxFunBase.BlockInterlacer((Ones(ℵ₀), Ones(ℵ₀)))

julia> @btime first($B, 10);
  1.212 μs (28 allocations: 2.31 KiB)
```
This PR
```julia
julia> @btime first($B, 10);
  38.610 ns (1 allocation: 224 bytes)
```