### PR TITLE
Don't cache TrivialInterlacer

### DIFF
--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -560,7 +560,7 @@ UncachedIterator(it::IT) where IT = UncachedIterator{eltype(it),IT}(it)
 iterate(it::UncachedIterator, st...) = iterate(it.iterator, st...)
 getindex(it::UncachedIterator, k) = it.iterator[k]
 
-Base.show(io::IO, C::UncachedIterator) = print(io, "Uncached wrapper around ", c.iterator)
+Base.show(io::IO, C::UncachedIterator) = print(io, "$UncachedIterator(", C.iterator, ")")
 
 ## Store iterator
 mutable struct CachedIterator{T,IT} <: AbstractCachedIterator{T,IT}

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -552,6 +552,7 @@ end
 Base.keys(c::AbstractCachedIterator) = oneto(length(c))
 length(A::AbstractCachedIterator) = length(A.iterator)
 
+# Lazy wrapper that mimics a CachedIterator, and has an `iterator` field
 struct UncachedIterator{T,IT} <: AbstractCachedIterator{T,IT}
     iterator :: IT
 end

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -543,10 +543,27 @@ Base.isless(x::PosInfinity, y::Block{1}) = isless(x, Int(y))
 pad(A::BandedMatrix,n,::Colon) = pad(A,n,n+A.u)  # Default is to get all columns
 columnrange(A,row::Integer) = max(1,row-bandwidth(A,1)):row+bandwidth(A,2)
 
+abstract type AbstractCachedIterator{T,IT} end
+eltype(it::Type{<:AbstractCachedIterator{T}}) where {T} = T
+function Base.IteratorSize(::Type{<:AbstractCachedIterator{<:Any,IT}}) where {IT}
+    Base.IteratorSize(IT) isa Base.IsInfinite ? Base.IsInfinite() : Base.HasLength()
+end
 
+Base.keys(c::AbstractCachedIterator) = oneto(length(c))
+length(A::AbstractCachedIterator) = length(A.iterator)
+
+struct UncachedIterator{T,IT} <: AbstractCachedIterator{T,IT}
+    iterator :: IT
+end
+UncachedIterator(it::IT) where IT = UncachedIterator{eltype(it),IT}(it)
+
+iterate(it::UncachedIterator, st...) = iterate(it.iterator, st...)
+getindex(it::UncachedIterator, k) = it.iterator[k]
+
+Base.show(io::IO, C::UncachedIterator) = print(io, "Uncached wrapper around ", c.iterator)
 
 ## Store iterator
-mutable struct CachedIterator{T,IT}
+mutable struct CachedIterator{T,IT} <: AbstractCachedIterator{T,IT}
     iterator::IT
     storage::Vector{T}
     state
@@ -582,15 +599,6 @@ function resize!(it::CachedIterator{T},n::Integer) where {T}
     it
 end
 
-
-eltype(it::Type{<:CachedIterator{T}}) where {T} = T
-
-function Base.IteratorSize(::Type{<:CachedIterator{<:Any,IT}}) where {IT}
-    Base.IteratorSize(IT) isa Base.IsInfinite ? Base.IsInfinite() : Base.HasLength()
-end
-
-Base.keys(c::CachedIterator) = oneto(length(c))
-
 iterate(it::CachedIterator) = iterate(it,1)
 function iterate(it::CachedIterator,st::Int)
     if  st > it.length && iterate(it.iterator,it.state...) === nothing
@@ -612,7 +620,6 @@ end
 @deprecate findfirst(A::CachedIterator, x) findfirst(x, A::CachedIterator)
 findfirst(x::T, A::CachedIterator{T}) where {T} = findfirst(==(x), A)
 
-length(A::CachedIterator) = length(A.iterator)
 
 ## nocat
 vnocat(A...) = Base.vect(A...)
@@ -676,7 +683,7 @@ conv(x::AbstractFill, y::AbstractFill) = DSP.conv(x, y)
 ## BlockInterlacer
 # interlaces coefficients by blocks
 # this has the property that all the coefficients of a block of a subspace
-# are grouped together, starting with the first bloc
+# are grouped together, starting with the first block
 #
 # TODO: cache sums
 
@@ -747,3 +754,33 @@ iterate(it::TrivialInterlacer{N,OneToInf{Int}}, st...) where {N} =
     iterate(Iterators.product(1:N, axes(it.blocks[1],1)), st...)
 
 cache(Q::BlockInterlacer) = CachedIterator(Q)
+
+# don't cache a trivial interlacer, as indexing into it is fast
+cache(Q::TrivialInterlacer) = UncachedIterator(Q)
+function Base.getindex(Q::TrivialInterlacer{N}, i::Int) where {N}
+    reverse(divrem(i-1,N) .+ 1)
+end
+function Base.getindex(Q::TrivialInterlacer, v::AbstractVector)
+    TrivialInterlacerSection(Q, v)
+end
+
+struct TrivialInterlacerSection{TI,I} <: AbstractVector{Tuple{Int,Int}}
+    interlacer::TI
+    inds::I
+end
+Base.size(t::TrivialInterlacerSection) = size(t.inds)
+Base.getindex(t::TrivialInterlacerSection, i::Int) = t.interlacer[t.inds[i]]
+function Base.getindex(t::TrivialInterlacerSection, i::AbstractVector{Int})
+    TrivialInterlacerSection(t.interlacer, t.inds[i])
+end
+function findsub(t::TrivialInterlacerSection{<:TrivialInterlacer{d}}, n::Int) where {d}
+    if 1 <= n <= d
+        ind1 = findfirst(x->x[1]==n, t) # d terms need to be searched at most
+        if ind1 === nothing
+            return oneunit(firstindex(t)):d:zero(length(t))
+        end
+        return ind1:d:length(t)
+    else
+        return oneunit(firstindex(t)):d:zero(length(t))
+    end
+end

--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -398,7 +398,7 @@ for TYP in (:BandedMatrix, :BlockBandedMatrix, :BandedBlockBandedMatrix, :Ragged
             cr=L.rangeinterlacer[kr]
             cd=L.domaininterlacer[jr]
             for ν=1:size(L.ops,1),μ=1:size(L.ops,2)
-                # indicies of ret
+                # indices of ret
                 ret_kr=findsub(cr,ν)
                 ret_jr=findsub(cd,μ)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,10 +66,26 @@ end
                 for (a,b) in it
                     @test a == b
                 end
+                C1 = cache(B1)
+                C2 = cache(B2)
+                for i in 0:nD
+                    indsB1 = ApproxFunBase.findsub(C1[1:10], i)
+                    indsB2 = ApproxFunBase.findsub(C2[1:10], i)
+                    @test indsB1 == indsB2
+                    indsB1 = ApproxFunBase.findsub(C1[2:2], i)
+                    indsB2 = ApproxFunBase.findsub(C2[2:2], i)
+                    @test indsB1 == indsB2
+                end
             end
             test_nD(1)
             test_nD(2)
             test_nD(3)
+
+            B = ApproxFunBase.BlockInterlacer((o, o))
+            C = cache(B)
+            @test contains(Base.sprint(show, C), "UncachedIterator($(repr(B)))")
+            @test first(C, 10) == C[1:10] == B[1:10] == first(B, 10)
+            @test C[2:10][1:2:end] == B[2:10][1:2:end]
         end
     end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -87,8 +87,9 @@
 		end
 	end
 	@testset "Iterators" begin
-		B = ApproxFunBase.BlockInterlacer((Ones{Int}(2), Ones{Int}(2)))
-		@test repr(B) == "ApproxFunBase.BlockInterlacer((Ones(2), Ones(2)))"
+		t = ([1,1], [1,1])
+		B = ApproxFunBase.BlockInterlacer(t)
+		@test repr(B) == "$(ApproxFunBase.BlockInterlacer)($(repr(t)))"
 		C = cache(B)
 		@test contains(repr(C), "Cached " * repr(B))
 	end


### PR DESCRIPTION
On master
```julia
julia> B = ApproxFunBase.interlacer(Fourier())
ApproxFunBase.BlockInterlacer((Ones(ℵ₀), Ones(ℵ₀)))

julia> @btime ApproxFunBase.cache($B)[1:100];
  19.937 μs (503 allocations: 40.66 KiB)

julia> f = Fun(Chebyshev(0..1) + Chebyshev(1..2))
Fun(Chebyshev(0..1) ⨄ Chebyshev(1..2), [0.5, 1.5, 0.5, 0.5])

julia> @btime Derivative() * $f;
  7.413 μs (128 allocations: 7.98 KiB)
```
This PR
```julia
julia> @btime ApproxFunBase.cache($B)[1:100];
  1.685 ns (0 allocations: 0 bytes)

julia> @btime Derivative() * $f;
  3.285 μs (60 allocations: 4.44 KiB)
```