### PR TITLE
Impove type inference in RaggedMatrix constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -355,7 +355,7 @@ for TYP in (:RaggedMatrix, :Matrix)
                 N = block(rangespace(A), last(parentindices(V)[1]))
                 M = block(domainspace(A), last(parentindices(V)[2]))
                 B = A[Block(1):N, Block(1):M]
-                RaggedMatrix(view(B, parentindices(V)...), _colstops(V))
+                RaggedMatrix{eltype(V)}(view(B, parentindices(V)...), _colstops(V))
             else
                 $def_TYP(V)
             end


### PR DESCRIPTION
This avoids recursion in the `RaggedMatrix` constructor from `SubOperator`s.
After this,
```julia
julia> d1, r1 = Legendre(), Jacobi(2,2);

julia> d2, r2 = Chebyshev(), Chebyshev();

julia> K = (Operator(I, d1) ⊗ Operator(I, d2)) → (r1 ⊗ r2)
KroneckerOperator : Legendre() ⊗ Chebyshev() → Jacobi(2,2) ⊗ Chebyshev()
 1.0  0.0  0.0       0.0  0.0       -0.285714  0.0  0.0        0.0        0.0       ⋯
  ⋅   1.0  0.0       0.0  0.0        0.0       0.0  0.0       -0.285714   0.0       ⋱
  ⋅   0.0  0.333333  0.0  0.0        0.0       0.0  0.0        0.0       -0.222222  ⋱
  ⋅    ⋅    ⋅        1.0  0.0        0.0       0.0  0.0        0.0        0.0       ⋱
  ⋅    ⋅    ⋅        0.0  0.333333   0.0       0.0  0.0        0.0        0.0       ⋱
  ⋅    ⋅    ⋅        0.0  0.0        0.214286  0.0  0.0        0.0        0.0       ⋱
  ⋅    ⋅    ⋅         ⋅    ⋅          ⋅        1.0  0.0        0.0        0.0       ⋱
  ⋅    ⋅    ⋅         ⋅    ⋅          ⋅        0.0  0.333333   0.0        0.0       ⋱
  ⋅    ⋅    ⋅         ⋅    ⋅          ⋅        0.0  0.0        0.214286   0.0       ⋱
  ⋅    ⋅    ⋅         ⋅    ⋅          ⋅        0.0  0.0        0.0        0.166667  ⋱
  ⋮    ⋱    ⋱         ⋱    ⋱          ⋱         ⋱    ⋱          ⋱          ⋱        ⋱

julia> @inferred K[1:1, 1:1]
1×1 ApproxFunBase.RaggedMatrix{Float64}:
 1.0
```