### PR TITLE
Backport v0.8: Impove type inference in RaggedMatrix constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.8.46"
+version = "0.8.47"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -355,7 +355,7 @@ for TYP in (:RaggedMatrix, :Matrix)
                 N = block(rangespace(A), last(parentindices(V)[1]))
                 M = block(domainspace(A), last(parentindices(V)[2]))
                 B = A[Block(1):N, Block(1):M]
-                RaggedMatrix(view(B, parentindices(V)...), _colstops(V))
+                RaggedMatrix{eltype(V)}(view(B, parentindices(V)...), _colstops(V))
             else
                 $def_TYP(V)
             end


### PR DESCRIPTION
Backport https://github.com/JuliaApproximation/ApproxFunBase.jl/pull/520 to v0.8