### PR TITLE
Improve inference in axpy for non-inferred operator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -830,7 +830,11 @@ const WrapperOperator = Union{SpaceOperator,MultiplicationWrapper,DerivativeWrap
 ## BLAS and matrix routines
 # We assume that copy may be overriden
 
-axpy!(a, X::Operator, Y::AbstractMatrix) = (Y .= a .* AbstractMatrix(X) .+ Y)
+function axpy!(a, X::Operator, Y::AbstractMatrix)
+    Y .+= a .* AbstractMatrix(X)
+    # the explicit return statement improves type inference
+    return Y
+end
 copyto!(dest::AbstractMatrix, src::Operator) = copyto!(dest, AbstractMatrix(src))
 
 # this is for operators that implement copy via axpy!


### PR DESCRIPTION
The following is type-inferred after this:
```julia
julia> d1, r1 = Legendre(), Jacobi(2,2);

julia> d2, r2 = Chebyshev(), Chebyshev();

julia> K = (Operator(I, d1) ⊗ Operator(I, d2)) → (r1 ⊗ r2);

julia> @inferred BandedBlockBandedMatrix(view(K, Block(1):Block(2), Block(1):Block(2)))
2×2-blocked 3×3 BandedBlockBandedMatrix{Float64, BlockArrays.PseudoBlockMatrix{Float64, Matrix{Float64}, Tuple{BlockArrays.BlockedUnitRange{Vector{Int64}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}}, BlockArrays.BlockedUnitRange{Vector{Int64}}}:
 1.0  │  0.0  0.0     
 ─────┼───────────────
  ⋅   │  1.0  0.0     
  ⋅   │   ⋅   0.333333
```