### PR TITLE
Call BandedBlockBandedMatrix directly in SubOperator RaggedMatrix

### DIFF
--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -354,7 +354,7 @@ for TYP in (:RaggedMatrix, :Matrix)
             elseif isbandedblockbanded(A)
                 N = block(rangespace(A), last(parentindices(V)[1]))
                 M = block(domainspace(A), last(parentindices(V)[2]))
-                B = A[Block(1):N, Block(1):M]
+                B = BandedBlockBandedMatrix(view(A, Block(1):N, Block(1):M))
                 RaggedMatrix{eltype(V)}(view(B, parentindices(V)...), _colstops(V))
             else
                 $def_TYP(V)


### PR DESCRIPTION
This avoids recursion, and improves performance slightly.
Master:
```julia
julia> @btime $K[1:1, 1:1]
  38.339 μs (168 allocations: 10.23 KiB)
1×1 ApproxFunBase.RaggedMatrix{Float64}:
 1.0
```
PR:
```julia
julia> @btime $K[1:1, 1:1]
  37.967 μs (166 allocations: 9.97 KiB)
1×1 ApproxFunBase.RaggedMatrix{Float64}:
 1.0
```