### PR TITLE
Improve inference in normalized space derivative

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/CalculusOperator.jl
+++ b/src/Operators/banded/CalculusOperator.jl
@@ -206,18 +206,19 @@ Base.@constprop :aggressive function DefaultDerivative(sp::Space, k::Number)
         csp = canonicalspace(sp)
         D1 = if csp == sp
             _Dsp = invfromcanonicalD(sp)*Derivative(setdomain(sp,canonicaldomain(sp)))
-            rsp = rangespace(_Dsp)
+            rsp = setdomain(rangespace(_Dsp), domain(sp))
             _Dsp
         else
             Dcsp = Derivative(csp)
             rsp = rangespace(Dcsp)
             Dcsp * Conversion_maybeconcrete(sp, csp, Val(:forward))
         end
-        D=DerivativeWrapper(SpaceOperator(D1,sp,setdomain(rsp,domain(sp))),1)
+        D=DerivativeWrapper(D1,1,sp,rsp)
         if k==1
-            D
+            return D
         else
-            DerivativeWrapper(TimesOperator(Derivative(rangespace(D),k-1),D), k, sp)
+            Drsp = Derivative(rsp,k-1)
+            DerivativeWrapper(TimesOperator(Drsp,D), k, sp, rangespace(Drsp))
         end
     end
 end


### PR DESCRIPTION
After this, the following is type-inferred:
```julia
julia> D = @inferred (S -> Derivative(S, 2))(NormalizedLegendre(0..1))
DerivativeWrapper : NormalizedLegendre(0 .. 1) → Jacobi(2,2,0 .. 1)
  ⋅    ⋅   26.8328    ⋅       ⋅      ⋅        ⋅        ⋅        ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅      52.915    ⋅      ⋅        ⋅        ⋅        ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅     90.0     ⋅        ⋅        ⋅        ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅   139.298     ⋅        ⋅        ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅     201.911     ⋅        ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅        ⋅     278.855     ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅        ⋅        ⋅     371.08     ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅        ⋅        ⋅        ⋅    479.479  ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅        ⋅        ⋅        ⋅       ⋅     ⋱
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅        ⋅        ⋅        ⋅       ⋅     ⋅
  ⋅    ⋅     ⋅        ⋅       ⋅      ⋅        ⋅        ⋅        ⋅       ⋅     ⋅
```