### PR TITLE
Promote rangespace/domainspace of Conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/Conversion.jl
+++ b/src/Operators/banded/Conversion.jl
@@ -27,7 +27,8 @@ end
 domainspace(C::ConcreteConversion)=C.domainspace
 rangespace(C::ConcreteConversion)=C.rangespace
 
-
+promotedomainspace(C::Conversion, sp::Space) = Conversion(sp, rangespace(C))
+promoterangespace(C::Conversion, sp::Space) = Conversion(domainspace(C), sp)
 
 function _implementconversionerror(a, b)
     error("Implement Conversion from ", typeof(a), " to ", typeof(b))


### PR DESCRIPTION
After this, the following works:
```julia
julia> Conversion(Chebyshev(), Ultraspherical(1)) : Ultraspherical(1)
ConversionWrapper : Ultraspherical(1) → Ultraspherical(1)
 1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅   1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅   1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅   1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅   1.0   ⋅    ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅   1.0   ⋅    ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0   ⋅    ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0   ⋅    ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0   ⋅   ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  ⋅
  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   ⋱
```