### PR TITLE
Fix ProductFun constructor ambiguity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/ProductFun.jl
+++ b/src/Multivariate/ProductFun.jl
@@ -115,7 +115,7 @@ end
 
 ## Adaptive construction
 
-function ProductFun(f::Function, sp::AbstractProductSpace{Tuple{S,V}}; tol=100eps()) where {S<:UnivariateSpace,V<:UnivariateSpace}
+function ProductFun(f::Function, sp::AbstractProductSpace{<:NTuple{2,UnivariateSpace}}; tol=100eps())
     for n = 50:100:5000
         X = coefficients(ProductFun(f,sp,n,n;tol=tol))
         if size(X,1)<n && size(X,2)<n
@@ -135,7 +135,11 @@ function ProductFun(f::Function,S::AbstractProductSpace,M::Integer,N::Integer;to
     vals=T[f(ptsx[k,j],ptsy[k,j]) for k=1:size(ptsx,1), j=1:size(ptsx,2)]
     ProductFun(transform!(S,vals),S;tol=tol,chopping=true)
 end
-ProductFun(f::Function,S::TensorSpace) = ProductFun(LowRankFun(f,S))
+_ProductFunLowRank(f, S) = ProductFun(LowRankFun(f,S))
+ProductFun(f::Function, S::TensorSpace{<:NTuple{2,UnivariateSpace}}) =
+    _ProductFunLowRank(f, S)
+ProductFun(f::Fun, S::TensorSpace{<:NTuple{2,UnivariateSpace}}) =
+    _ProductFunLowRank(f, S)
 
 ProductFun(f,dx::Space,dy::Space)=ProductFun(f,TensorSpace(dx,dy))
 

--- a/src/Multivariate/ProductFun.jl
+++ b/src/Multivariate/ProductFun.jl
@@ -136,9 +136,9 @@ function ProductFun(f::Function,S::AbstractProductSpace,M::Integer,N::Integer;to
     ProductFun(transform!(S,vals),S;tol=tol,chopping=true)
 end
 _ProductFunLowRank(f, S) = ProductFun(LowRankFun(f,S))
-ProductFun(f::Function, S::TensorSpace{<:NTuple{2,UnivariateSpace}}) =
+ProductFun(f::Function, S::TensorSpace2D) =
     _ProductFunLowRank(f, S)
-ProductFun(f::Fun, S::TensorSpace{<:NTuple{2,UnivariateSpace}}) =
+ProductFun(f::Fun, S::TensorSpace2D) =
     _ProductFunLowRank(f, S)
 
 ProductFun(f,dx::Space,dy::Space)=ProductFun(f,TensorSpace(dx,dy))
@@ -184,7 +184,7 @@ end
 
 ## Conversion to other ProductSpaces with the same coefficients
 
-ProductFun(f::ProductFun,sp::TensorSpace)=space(f)==sp ? f : ProductFun(coefficients(f,sp),sp)
+ProductFun(f::ProductFun,sp::TensorSpace2D)=space(f)==sp ? f : ProductFun(coefficients(f,sp),sp)
 ProductFun(f::ProductFun{S,V,SS},sp::ProductDomain) where {S,V,SS<:TensorSpace}=ProductFun(f,Space(sp))
 
 function ProductFun(f::ProductFun,sp::AbstractProductSpace)


### PR DESCRIPTION
This makes the following work:
```julia
julia> ProductFun(Fun((x,y)->x*y, Chebyshev()^2), Chebyshev()^2)
ProductFun on Chebyshev() ⊗ Chebyshev()
```