### PR TITLE
Show for `Tensorizer`

### DIFF
--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -24,13 +24,15 @@ factor(d::AbstractProductSpace,k) = factors(d)[k]
 # would be Tensorizer((Ones{Int}(∞), Fill(2,∞)))
 
 
-struct Tensorizer{DMS<:Tuple}
+struct Tensorizer{DMS<:Tuple{Vararg{AbstractVector{Int}}}}
     blocks::DMS
 end
 
 const InfOnes = Ones{Int,1,Tuple{OneToInf{Int}}}
 const Tensorizer2D{AA, BB} = Tensorizer{Tuple{AA, BB}}
 const TrivialTensorizer{d} = Tensorizer{NTuple{d,InfOnes}}
+
+show(io::IO, t::Tensorizer) = print(io, Tensorizer, "(",  t.blocks, ")")
 
 eltype(::Type{<:Tensorizer{<:Tuple{Vararg{Any,N}}}}) where {N} = NTuple{N,Int}
 dimensions(a::Tensorizer) = map(sum,a.blocks)

--- a/test/show.jl
+++ b/test/show.jl
@@ -100,4 +100,9 @@
 		C = cache(B)
 		@test contains(repr(C), "Cached " * repr(B))
 	end
+	@testset "Tensorizer" begin
+		o = Ones(Int,ℵ₀)
+		t = ApproxFunBase.Tensorizer((o,o))
+		@test repr(t) == "ApproxFunBase.Tensorizer($((o,o)))"
+	end
 end


### PR DESCRIPTION
After this,
```julia
julia> ApproxFunBase.tensorizer(Chebyshev()^2)
ApproxFunBase.Tensorizer((Ones(ℵ₀), Ones(ℵ₀)))
```
vs master
```julia
julia> ApproxFunBase.tensorizer(Chebyshev()^2)
ApproxFunBase.Tensorizer{Tuple{FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, FillArrays.Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}}((Ones(ℵ₀), Ones(ℵ₀)))
```

Also, restricts `Tensorizer` to tuples of `AbstractVector{Int}`.