### PR TITLE
Check size in mul_coefficients

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/SubOperator.jl
+++ b/src/Operators/SubOperator.jl
@@ -378,18 +378,18 @@ end
 
 
 function mul_coefficients(A::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}}, b)
-    if size(A,2) == length(b)
+    if size(A,2) == size(b,1)
         AbstractMatrix(A)*b
     else
-        AbstractMatrix(view(A,:,1:length(b)))*b
+        AbstractMatrix(view(A,:,axes(b,1)))*b
     end
 end
 function mul_coefficients!(A::SubOperator{<:Any,<:Any,NTuple{2,UnitRange{Int}}}, b,
         temp = similar(b, promote_type(eltype(A), eltype(b)), size(A,1)))
-    if size(A,2) == length(b)
+    if size(A,2) == size(b,1)
         mul!(temp, AbstractMatrix(A), b)
     else
-        mul!(temp, AbstractMatrix(view(A,:,1:length(b))), b)
+        mul!(temp, AbstractMatrix(view(A,:,axes(b,1))), b)
     end
     b .= temp
     return b


### PR DESCRIPTION
Instead of `length(b)`, we use `size(b,1)`, which allows trailing dimensions.