### PR TITLE
Fix show for Fun in an ArraySpace

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -10,16 +10,6 @@ function show(io::IO, f::Fun)
     print(io,")")
 end
 
-evalconst(f, ::AnyDomain) = f(0.0)
-evalconst(f, d) = f(leftendpoint(d))
-evalconst(f, d::Union{Point, UnionDomain{<:Any, <:Tuple{Point, Vararg{Point}}}}) = f(d)
-
-function show(io::IO,f::Fun{<:Union{ConstantSpace, ArraySpace{<:ConstantSpace}}})
-    d = domain(f)
-    print(io, evalconst(f, domain(f)))
-    print(io, d isa AnyDomain ? " anywhere" : " on " * string(d))
-end
-
 ## MultivariateFun
 
 show(io::IO, ::MIME"text/plain", f::MultivariateFun) = show(io, f)

--- a/src/show.jl
+++ b/src/show.jl
@@ -149,9 +149,8 @@ end
 
 summarystr(ss::ArraySpace) = string(Base.dims2string(length.(axes(ss))), " ArraySpace")
 summary(io::IO, ss::ArraySpace) = print(io, summarystr(ss))
-function show(io::IO,ss::ArraySpace;header::Bool=true)
-    header && print(io,summarystr(ss)*":\n")
-    show(io, ss.spaces)
+function show(io::IO, ss::ArraySpace; header::Bool=true)
+    print(io, ArraySpace, "(", ss.spaces, ")")
 end
 
 function show(io::IO,s::TensorSpace)

--- a/test/show.jl
+++ b/test/show.jl
@@ -42,6 +42,12 @@
 			@test startswith(rpr, "PiecewiseSpace")
 			@test contains(rpr, repr(p))
 		end
+		@testset "ArraySpace" begin
+			spaces = [PointSpace(1:1), PointSpace(2:2)]
+			A = ApproxFunBase.ArraySpace(spaces)
+			@test startswith(repr(A), "$(ApproxFunBase.ArraySpace)")
+			@test contains(repr(A), repr(spaces))
+		end
 	end
 	@testset "Fun" begin
 		f = Fun(PointSpace(1:3), [1,2,3])


### PR DESCRIPTION
This removes the show method for `Fun{<:Union{ConstantSpace, ArraySpace{<:ConstantSpace}}}`, as the special cases were becoming unwieldy to maintain

Fixes the display for
```julia
julia> D2 = Dirichlet(Chebyshev(),1);

julia> D2 * Fun()
Fun(ApproxFunBase.ArraySpace(ConstantSpace{Point{Float64}, Float64}[ConstantSpace(Point(-1.0)), ConstantSpace(Point(1.0))]), [1.0])
```