### PR TITLE
Fix bandwidth for InterlaceOperator

### DIFF
--- a/src/Operators/general/InterlaceOperator.jl
+++ b/src/Operators/general/InterlaceOperator.jl
@@ -131,7 +131,7 @@ Base.@constprop :aggressive function interlace_bandwidths(ops::AbstractMatrix{<:
         # special case for example
         l,u = max(bandwidth(ops[1],1),bandwidth(ops[2],1)-1),bandwidth(ops[2],2)+1
     else
-        l,u = (1-dimension(rs),dimension(ds)-1)  # not banded
+        l,u = (dimension(rs)-1,dimension(ds)-1)  # not banded
     end
 
     l,u
@@ -168,7 +168,7 @@ Base.@constprop :aggressive function interlace_bandwidths(ops::VectorOrTupleOfOp
             u = max(u, p*opbw[2]+1-k)
         end
     else
-        l,u = (1-dimension(rs),dimension(ds)-1)  # not banded
+        l,u = (dimension(rs)-1,dimension(ds)-1)  # not banded
     end
     l,u
 end


### PR DESCRIPTION
After this,
```julia
julia> C = [Dirichlet(Chebyshev()); Dirichlet(Chebyshev(),1)];

julia> Q = QuotientSpace(Chebyshev(), C);

julia> Z = Conversion(Q, Chebyshev());

julia> isapprox((C * Z)[:, 1:5], C[:,1:9] * Z[1:9, 1:5], atol=1e-14)
true
```