### PR TITLE
Fix cumsum for piecewise spaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.8"
+version = "0.9.9"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/SumSpace.jl
+++ b/src/Spaces/SumSpace.jl
@@ -319,12 +319,12 @@ for TYP in (:SumSpace,:PiecewiseSpace), OP in (:(Base.sum),:linesum)
     @eval $OP(f::Fun{V}) where {V<:$TYP} = mapreduce($OP,+,components(f))
 end
 
-function Base.cumsum(f::Fun{V}) where V<:PiecewiseSpace
-    vf=components(f)
-    r=zero(cfstype(f))
-    for k=1:length(vf)
-        vf[k]=cumsum(vf[k]) + r
-        r=last(vf[k])
+function Base.cumsum(f::Fun{<:PiecewiseSpace})
+    vf = cumsum.(components(f))
+    r = zero(cfstype(vf))
+    for k in eachindex(vf)
+        vf[k] += r
+        r = last(vf[k])
     end
     Fun(vf,PiecewiseSpace)
 end


### PR DESCRIPTION
Fix https://github.com/JuliaApproximation/ApproxFun.jl/issues/905
After this,
```julia
julia> x = Fun()
Fun(Chebyshev(), [0.0, 1.0])

julia> cumsum(sign(x))
Fun(Chebyshev(the segment [-1.0,-0.0]) ⨄ Chebyshev(the segment [-0.0,1.0]), [-0.5, -0.5, -0.5, 0.5])
```