### PR TITLE
Fix `maximum(abs, ::Fun)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.9"
+version = "0.9.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -569,17 +569,17 @@ for op in (:(maximum),:(minimum))
     @eval begin
         function $op(::typeof(abs), f::Fun{<:RealSpace,<:Real})
             pts = iszero(f') ? [leftendpoint(domain(f))] : extremal_args(f)
-            _maybemap($op, f, pts)
+            _maybemap($op, abs(f), pts)
         end
         function $op(::typeof(abs), f::Fun)
             # complex spaces/types can have different extrema
             pts = extremal_args(abs(f))
-            _maybemap($op, f, pts)
+            _maybemap($op, abs(f), pts)
         end
         $op(f::Fun{PiecewiseSpace{<:Any,<:UnionDomain,<:Real},<:Real}) =
-            $op(map($op,components(f)))
+            $op(map($op, components(f)))
         $op(::typeof(abs), f::Fun{PiecewiseSpace{<:Any,<:UnionDomain,<:Real},<:Real}) =
-            $op(abs, map(g -> $op(abs, g),components(f)))
+            $op(abs, map(g -> $op(abs, g), components(f)))
     end
 end
 


### PR DESCRIPTION
Fix https://github.com/JuliaApproximation/ApproxFun.jl/issues/907

After this,
```julia
julia> x = Fun()
Fun(Chebyshev(), [0.0, 1.0])

julia> a = abs(x)
Fun(ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}(PiecewiseSegment{Float64, Vector{Float64}}([-1.0, -0.0, 1.0])), [1.0, 5.55112e-17, 1.0])

julia> using LinearAlgebra

julia> norm(x - a, Inf)
2.0

julia> norm(a - x, Inf)
2.0
```