### PR TITLE
Accept vectors in `PiecewiseSpace`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.11"
+version = "0.9.12"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -147,6 +147,8 @@ function _IteratorSize(::Type{T}) where {T<:Tuple}
     any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasLength()
 end
 
+_IteratorSize(::Type{<:AbstractVector{<:AbstractFill{<:Any,<:Any,
+        <:Tuple{Vararg{InfRanges}}}}}) = Base.IsInfinite()
 _IteratorSize(::Type{<:AbstractVector{<:InfRanges}}) = Base.IsInfinite()
 _IteratorSize(::Type{<:AbstractVector{<:Union{Vector{<:Integer},
                                     SVector{<:Any,<:Integer}}}}) = Base.HasLength()

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -148,8 +148,8 @@ function _IteratorSize(::Type{T}) where {T<:Tuple}
 end
 
 _IteratorSize(::Type{<:AbstractVector{<:InfRanges}}) = Base.IsInfinite()
-_IteratorSize(::Type{<:AbstractVector{<:Vector{<:Integer}}}) = Base.HasLength()
-_IteratorSize(::Type{<:AbstractVector{<:SVector{<:Integer}}}) = Base.HasLength()
+_IteratorSize(::Type{<:AbstractVector{<:Union{Vector{<:Integer},
+                                    SVector{<:Any,<:Integer}}}}) = Base.HasLength()
 _IteratorSize(::Type{<:AbstractVector}) = Base.SizeUnknown()
 
 tuple_to_SVector(t::Tuple) = SVector(t)

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -147,6 +147,15 @@ function _IteratorSize(::Type{T}) where {T<:Tuple}
     any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasLength()
 end
 
+_IteratorSize(::Type{<:AbstractVector{<:InfRanges}}) = Base.IsInfinite()
+_IteratorSize(::Type{<:AbstractVector{<:Vector{<:Integer}}}) = Base.HasLength()
+_IteratorSize(::Type{<:AbstractVector{<:SVector{<:Integer}}}) = Base.HasLength()
+_IteratorSize(::Type{<:AbstractVector}) = Base.SizeUnknown()
+
+tuple_to_SVector(t::Tuple) = SVector(t)
+tuple_to_SVector(x) = x
+_vcat_toabsvec(args...) = mapreduce(tuple_to_SVector, vcat, args)
+
 include("LinearAlgebra/LinearAlgebra.jl")
 include("Fun.jl")
 include("onehotvector.jl")

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -365,12 +365,16 @@ using LinearAlgebra
     @testset "PiecewiseSpace" begin
         ps = PiecewiseSpace([PointSpace(1:2), PointSpace(3:4)])
         @test PiecewiseSpace(ps, ps) == ps
-        @test_broken PiecewiseSpace(ps, PointSpace(1:2)) == ps
-        @test_broken PiecewiseSpace(PointSpace(1:2), ps) == ps
+        @test ApproxFunBase.canonicalspace(ps) == ps
         d = domain(ps)
         @test all(x -> x in d, 1:4)
         @test all(x -> !(x in d), 5:6)
         d2 = domain(PiecewiseSpace(ps, PointSpace(5:6)))
         @test all(x -> x in d2, 5:6)
+        d2 = domain(PiecewiseSpace(PointSpace(5:6), ps))
+        @test all(x -> x in d2, 5:6)
+
+        ps2 = PiecewiseSpace([PointSpace(3:4), PointSpace(1:2)])
+        @test ApproxFunBase.canonicalspace(ps2) == ps
     end
 end

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -361,4 +361,16 @@ using LinearAlgebra
         @test length(A) == 0
         @test ApproxFunBase.dimension(A) == 0
     end
+
+    @testset "PiecewiseSpace" begin
+        ps = PiecewiseSpace([PointSpace(1:2), PointSpace(3:4)])
+        @test PiecewiseSpace(ps, ps) == ps
+        @test_broken PiecewiseSpace(ps, PointSpace(1:2)) == ps
+        @test_broken PiecewiseSpace(PointSpace(1:2), ps) == ps
+        d = domain(ps)
+        @test all(x -> x in d, 1:4)
+        @test all(x -> !(x in d), 5:6)
+        d2 = domain(PiecewiseSpace(ps, PointSpace(5:6)))
+        @test all(x -> x in d2, 5:6)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,21 @@ end
             @test first(C, 10) == C[1:10] == B[1:10] == first(B, 10)
             @test C[2:10][1:2:end] == B[2:10][1:2:end]
         end
+
+        a = [1,2]
+        sa = SVector(1,2)
+        f = Fill(2,∞)
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer((f, f))) == Base.IsInfinite()
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer([f, f])) == Base.IsInfinite()
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer((1:∞, 1:∞))) == Base.IsInfinite()
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer([1:∞, 1:∞])) == Base.IsInfinite()
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer([sa, sa])) == Base.HasLength()
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer([a, a])) == Base.HasLength()
+        @test Base.IteratorSize(ApproxFunBase.BlockInterlacer((a, a))) == Base.HasLength()
+
+        b1 = ApproxFunBase.BlockInterlacer([Fill(2,2), 1:2])
+        b2 = ApproxFunBase.BlockInterlacer((Fill(2,2), 1:2))
+        @test collect(b1) == collect(b2)
     end
 
     @testset "issue #94" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Infinities
 using LinearAlgebra
 using Random
 using SpecialFunctions
+using StaticArrays
 using Test
 
 @testset "Project quality" begin


### PR DESCRIPTION
Currently, `PiecewiseSpace` converts vectors to `Tuples`, which is intrinsically type-unstable. Since it is often used in contexts where the number of terms isn't known at compile time (e.g. `roots`), the way to improve type-inference is to allow vector arguments.

Along with https://github.com/JuliaArrays/FillArrays.jl/pull/291, this makes the following type-inferred as a `Union`:
```julia
julia> s = space(abs(Fun()));

julia> @code_typed Derivative(s)
CodeInfo(
1 ─ %1 = Core.getfield(x, 1)::ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}
│   %2 = invoke ApproxFunBase.DefaultDerivative(%1::ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}, 1::Int64)::Union{ApproxFunBase.DerivativeWrapper{TimesOperator{Float64, Tuple{Int64, Int64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Operator{Float64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Tuple{Int64, Int64}}, ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}, PiecewiseSpace{Vector{Ultraspherical{Int64, Segment{Float64}, Float64}}, DomainSets.UnionDomain{Float64, Vector{Segment{Float64}}}, Float64}, Int64, Float64}, ApproxFunBase.DerivativeWrapper{TimesOperator{Float64, Tuple{Int64, Int64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Operator{Float64}, Tuple{Int64, Int64}, Tuple{Int64, Int64}}, ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}, PiecewiseSpace{Vector{Ultraspherical{Int64, Segment{Float64}, Float64}}, DomainSets.UnionDomain{Float64, Vector{Segment{Float64}}}, Float64}, Int64, Float64}}
└──      return %2
) => Union{ApproxFunBase.DerivativeWrapper{TimesOperator{Float64, Tuple{Int64, Int64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Operator{Float64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Tuple{Int64, Int64}}, ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}, PiecewiseSpace{Vector{Ultraspherical{Int64, Segment{Float64}, Float64}}, DomainSets.UnionDomain{Float64, Vector{Segment{Float64}}}, Float64}, Int64, Float64}, ApproxFunBase.DerivativeWrapper{TimesOperator{Float64, Tuple{Int64, Int64}, Tuple{Infinities.InfiniteCardinal{0}, Infinities.InfiniteCardinal{0}}, Operator{Float64}, Tuple{Int64, Int64}, Tuple{Int64, Int64}}, ContinuousSpace{Float64, Float64, PiecewiseSegment{Float64, Vector{Float64}}}, PiecewiseSpace{Vector{Ultraspherical{Int64, Segment{Float64}, Float64}}, DomainSets.UnionDomain{Float64, Vector{Segment{Float64}}}, Float64}, Int64, Float64}}
```