### PR TITLE
Export `\biC` as an alias for `tocanonical`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.11"
+version = "0.9.12"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -2,7 +2,7 @@ export Domain, SegmentDomain, tocanonical, fromcanonical, fromcanonicalD, ∂
 export isambiguous, arclength
 export components, component, ncomponents
 
-
+export 𝑪
 
 
 # add indexing for all spaces, not just DirectSumSpace
@@ -118,6 +118,7 @@ maps the point `x` in `d` to a point in `canonical(d,x)`
 """
 function tocanonical end
 
+const 𝑪 = tocanonical
 
 ## conveninece routines
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -172,5 +172,4 @@ show(io::IO,::ConstantSpace{AnyDomain}) = print(io,"ConstantSpace")
 show(io::IO,S::ConstantSpace) = print(io,"ConstantSpace($(domain(S)))")
 
 ## Segment
-
-show(io::IO,d::Segment) = print(io,"the segment [$(leftendpoint(d)),$(rightendpoint(d))]")
+show(io::IO,d::Segment) = print(io, "Segment($(leftendpoint(d)), $(rightendpoint(d)))")


### PR DESCRIPTION
After this,
```julia
julia> 𝑪(0..0.5, 0)
-1.0

julia> 𝑪(0..0.5, 0.5)
1.0
```

This is quite a useful operation, and it's helpful to have a shortcut. The plan is to use this in displaying spaces where the variable needs to be mapped to the canonical domain.

Suggestions for a better symbol are welcome. I have picked this arbitrarily, thinking that it's unlikely to clash with other packages.

Also, this changes the displayed form for `Segment` to make it round-trippable.
```julia
julia> Segment(0, 1)
Segment(0.0, 1.0)
```