### PR TITLE
Improve type-inference in multiplying with TimesOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.12"
+version = "0.9.13"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Operators/banded/Multiplication.jl
+++ b/src/Operators/banded/Multiplication.jl
@@ -79,7 +79,7 @@ getindex(D::ConcreteMultiplication{F,UnsetSpace,T},k::Integer,j::Integer) where 
 ##multiplication can always be promoted, range space is allowed to change
 promotedomainspace(D::Multiplication, sp::UnsetSpace) = D
 function promotedomainspace(D::Multiplication, sp::Space)
-    if domainspace(D) == sp
+    if domainspace(D) === sp
         D
     else
         Multiplication(D.f,sp)

--- a/src/Operators/general/algebra.jl
+++ b/src/Operators/general/algebra.jl
@@ -332,8 +332,10 @@ Base.@constprop :aggressive function promotetimes(opsin,
     anytimesop = any(x -> x isa TimesOperator, ops)
     TimesOperator(convert_vector(ops), bw, sz, bbw, sbbw, ibbb, irb, isaf; anytimesop)
 end
+maybenarroweltype(::AbstractVector{Operator{T}}) where {T} = Operator{T}
+maybenarroweltype(opsin) = mapreduce(operatortype, promote_type, opsin)
 function __promotetimes(opsin, dsp, anytimesop)
-    ops = Vector{mapreduce(operatortype, promote_type, opsin)}(undef, 0)
+    ops = Vector{maybenarroweltype(opsin)}(undef, 0)
     sizehint!(ops, length(opsin))
 
     for k in reverse(eachindex(opsin))
@@ -614,7 +616,7 @@ function A_mul_B(A::Operator, B::Operator; dspB=domainspace(B), rspA=rangespace(
     elseif isconstop(B)
         promotedomainspace(strictconvert(Number, B) * A, dspB)
     else
-        promotetimes(collateops(*, A, B), dspB, false)
+        promotetimes(collateops(*, A : rangespace(B), B), dspB, false)
     end
 end
 


### PR DESCRIPTION
This makes the following type-inferred:
```julia
julia> M = Multiplication(Fun(),Chebyshev());

julia> @inferred M * M * M
TimesOperator : Chebyshev() → Chebyshev()
 0.0   0.375  0.0    0.125   ⋅      ⋅      ⋅      ⋅      ⋅      ⋅     ⋅
 0.75  0.0    0.5    0.0    0.125   ⋅      ⋅      ⋅      ⋅      ⋅     ⋅
 0.0   0.5    0.0    0.375  0.0    0.125   ⋅      ⋅      ⋅      ⋅     ⋅
 0.25  0.0    0.375  0.0    0.375  0.0    0.125   ⋅      ⋅      ⋅     ⋅
  ⋅    0.125  0.0    0.375  0.0    0.375  0.0    0.125   ⋅      ⋅     ⋅
  ⋅     ⋅     0.125  0.0    0.375  0.0    0.375  0.0    0.125   ⋅     ⋅
  ⋅     ⋅      ⋅     0.125  0.0    0.375  0.0    0.375  0.0    0.125  ⋅
  ⋅     ⋅      ⋅      ⋅     0.125  0.0    0.375  0.0    0.375  0.0    ⋱
  ⋅     ⋅      ⋅      ⋅      ⋅     0.125  0.0    0.375  0.0    0.375  ⋱
  ⋅     ⋅      ⋅      ⋅      ⋅      ⋅     0.125  0.0    0.375  0.0    ⋱
  ⋅     ⋅      ⋅      ⋅      ⋅      ⋅      ⋅      ⋱      ⋱      ⋱     ⋱
```