### PR TITLE
Don't treat ConstantOperator as a zeroop

### DIFF
--- a/src/Operators/banded/ConstantOperator.jl
+++ b/src/Operators/banded/ConstantOperator.jl
@@ -164,7 +164,6 @@ isconstop(::Union{ZeroOperator,ConstantOperator}) = true
 isconstop(S::SpaceOperator) = isconstop(S.op)
 
 iszeroop(::ZeroOperator) = true
-iszeroop(A::ConstantOperator) = A.λ==0.0
 iszeroop(A) = false
 
 convert(::Type{T},::ZeroOperator) where {T<:Number} = zero(T)


### PR DESCRIPTION
This should make `iszeroop` an operation that works on types, and not values, which would help with type-inference