### PR TITLE
Implement calculus operations for ConstantSpace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.14"
+version = "0.9.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -254,7 +254,7 @@ choosedomainspace(M::ConcreteMultiplication{D,UnsetSpace},sp::Space) where {D<:C
 Base.isfinite(f::Fun{CS}) where {CS<:ConstantSpace} = isfinite(Number(f))
 
 
+## Calculus
 
-
-
-
+integrate(f::Fun{<:ConstantSpace{<:IntervalOrSegment}}) = Number(f) * Fun(Chebyshev(domain(f)))
+differentiate(f::Fun{<:ConstantSpace{<:IntervalOrSegment}}) = zero(f)

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -256,5 +256,5 @@ Base.isfinite(f::Fun{CS}) where {CS<:ConstantSpace} = isfinite(Number(f))
 
 ## Calculus
 
-integrate(f::Fun{<:ConstantSpace{<:IntervalOrSegment}}) = Number(f) * Fun(Chebyshev(domain(f)))
+integrate(f::Fun{<:ConstantSpace{<:IntervalOrSegment}}) = Number(f) * Fun(domain(f))
 differentiate(f::Fun{<:ConstantSpace{<:IntervalOrSegment}}) = zero(f)

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -309,6 +309,7 @@ using LinearAlgebra
         @test g > f
         @test g >= f
         @test 1 < f < 3
+        @test norm(f) == 2
 
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(Point(2))) == ConstantSpace(Point(1) ∪ Point(2))
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(AnyDomain())) == ConstantSpace(Point(1))

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -309,7 +309,6 @@ using LinearAlgebra
         @test g > f
         @test g >= f
         @test 1 < f < 3
-        @test norm(f) == 2
 
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(Point(2))) == ConstantSpace(Point(1) ∪ Point(2))
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(AnyDomain())) == ConstantSpace(Point(1))

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -309,6 +309,7 @@ using LinearAlgebra
         @test g > f
         @test g >= f
         @test 1 < f < 3
+        @test differentiate(f) == Fun(0, ConstantSpace(0..1))
 
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(Point(2))) == ConstantSpace(Point(1) ∪ Point(2))
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(AnyDomain())) == ConstantSpace(Point(1))


### PR DESCRIPTION
I have implemented the `integrate` and `differentiate` methods for `ConstantSpace`. This addition was motivated to add support for taking the norm of ConstantSpace functionals. I have also added a test for the norm operation.