### PR TITLE
Fix ConstantSpace Multiplication for empty coefficients

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.15"
+version = "0.9.16"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -6,7 +6,7 @@ iterate(f::Fun{SequenceSpace}, st) = f[st], st+1
 
 getindex(f::Fun{SequenceSpace}, k::Integer) =
     k ≤ ncoefficients(f) ? f.coefficients[k] : zero(cfstype(f))
-getindex(f::Fun{SequenceSpace},K::CartesianIndex{0}) = f[1]
+getindex(f::Fun{SequenceSpace},K::CartesianIndex{0}) = _first_or_zero(f)
 getindex(f::Fun{SequenceSpace},K) = cfstype(f)[f[k] for k in K]
 
 length(f::Fun{SequenceSpace}) = ℵ₀
@@ -80,7 +80,10 @@ ones(S::ConstantSpace) = Fun(S,fill(1.0,1))
 ones(S::Union{AnyDomain,UnsetSpace}) = ones(ConstantSpace())
 zeros(S::AnyDomain) = zero(ConstantSpace())
 zero(S::UnsetSpace) = zero(ConstantSpace())
-evaluate(f::AbstractVector,::ConstantSpace,x...)=f[1]
+_first_or_zero(f::AbstractVector) = get(f, 1, zero(eltype(f)))
+function evaluate(f::AbstractVector,::ConstantSpace,x...)
+    _first_or_zero(f)
+end
 evaluate(f::AbstractVector,::ZeroSpace,x...)=zero(eltype(f))
 
 
@@ -176,8 +179,7 @@ bandwidths(D::ConcreteMultiplication{CS1,CS2,T}) where {CS1<:ConstantSpace,CS2<:
 
 function getindex(D::ConcreteMultiplication{<:ConstantSpace,<:ConstantSpace,T},k::Integer,j::Integer) where {T}
     if k==j==1
-        (; f) = D
-        c = ncoefficients(f) == 0 ? zero(cfstype(f)) : coefficient(f,1)
+        c = _first_or_zero(coefficients(D.f))
         strictconvert(T, c)
     else
         one(T)

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -173,8 +173,16 @@ defaultMultiplication(f::Fun,b::ConstantSpace) = ConcreteMultiplication(f,b)
 
 bandwidths(D::ConcreteMultiplication{CS1,CS2,T}) where {CS1<:ConstantSpace,CS2<:ConstantSpace,T} =
     0,0
-getindex(D::ConcreteMultiplication{CS1,CS2,T},k::Integer,j::Integer) where {CS1<:ConstantSpace,CS2<:ConstantSpace,T} =
-    k==j==1 ? strictconvert(T,D.f.coefficients[1]) : one(T)
+
+function getindex(D::ConcreteMultiplication{<:ConstantSpace,<:ConstantSpace,T},k::Integer,j::Integer) where {T}
+    if k==j==1
+        (; f) = D
+        c = ncoefficients(f) == 0 ? zero(cfstype(f)) : coefficient(f,1)
+        strictconvert(T, c)
+    else
+        one(T)
+    end
+end
 
 rangespace(D::ConcreteMultiplication{CS1,CS2,T}) where {CS1<:ConstantSpace,CS2<:ConstantSpace,T} =
     D.space

--- a/src/show.jl
+++ b/src/show.jl
@@ -168,7 +168,7 @@ function show(io::IO,s::SubSpace)
     show(io,s.indexes)
 end
 
-show(io::IO,::ConstantSpace{AnyDomain}) = print(io,"ConstantSpace")
+show(io::IO,::ConstantSpace{AnyDomain}) = print(io,"ConstantSpace()")
 show(io::IO,S::ConstantSpace) = print(io,"ConstantSpace($(domain(S)))")
 
 ## Segment

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -316,7 +316,10 @@ using LinearAlgebra
         @test maxspace(ConstantSpace(AnyDomain()), ConstantSpace(Point(2))) == ConstantSpace(Point(2))
         @test maxspace(ConstantSpace(AnyDomain()), ConstantSpace(AnyDomain())) == ConstantSpace(AnyDomain())
 
-        C = Multiplication(Fun(ConstantSpace(), Float64[]), ConstantSpace())
+        f = Fun(ConstantSpace(), Float64[])
+        @test f(0) == 0
+
+        C = Multiplication(f, space(f))
         @test all(iszero, AbstractMatrix(C))
     end
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -315,6 +315,9 @@ using LinearAlgebra
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(AnyDomain())) == ConstantSpace(Point(1))
         @test maxspace(ConstantSpace(AnyDomain()), ConstantSpace(Point(2))) == ConstantSpace(Point(2))
         @test maxspace(ConstantSpace(AnyDomain()), ConstantSpace(AnyDomain())) == ConstantSpace(AnyDomain())
+
+        C = Multiplication(Fun(ConstantSpace(), Float64[]), ConstantSpace())
+        @test all(iszero, AbstractMatrix(C))
     end
 
     @testset "promotion" begin

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -317,9 +317,12 @@ using LinearAlgebra
         @test maxspace(ConstantSpace(AnyDomain()), ConstantSpace(AnyDomain())) == ConstantSpace(AnyDomain())
 
         f = Fun(ConstantSpace(), Float64[])
-        @test f(0) == 0
+        g = Fun(ConstantSpace(), Float64[0])
+        @test f(0) == g(0) == 0
 
         C = Multiplication(f, space(f))
+        @test all(iszero, AbstractMatrix(C))
+        C = Multiplication(g, space(g))
         @test all(iszero, AbstractMatrix(C))
     end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -9,7 +9,7 @@
 	end
 	@testset "Space" begin
 		@testset "ConstantSpace" begin
-			@test contains(repr(ConstantSpace()), "ConstantSpace")
+			@test repr(ConstantSpace()) == "ConstantSpace()"
 			c = ConstantSpace(0..1)
 			@test startswith(repr(c), "ConstantSpace")
 			@test contains(repr(c), repr(domain(c)))


### PR DESCRIPTION
After this, the following works (the `Fun` has an empty coefficient vector):
```julia
julia> C = Multiplication(Fun(ConstantSpace(), Float64[]), ConstantSpace())
ConcreteMultiplication : ConstantSpace → ConstantSpace
 0.0
```