### PR TITLE
Remove fromcanonical in points for BivariateSpace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.15"
+version = "0.9.16"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -565,10 +565,18 @@ end
 points(d::Union{EuclideanDomain{2},BivariateSpace},n,m) = points(d,n,m,1),points(d,n,m,2)
 
 function points(d::BivariateSpace,n,m,k)
-    ptsx=points(columnspace(d,1),n)
-    ptst=points(factor(d,2),m)
+    k ∈ (1,2) || throw(ArgumentError("k must be 1 or 2"))
 
-    promote_type(eltype(ptsx),eltype(ptst))[fromcanonical(d,x,t)[k] for x in ptsx, t in ptst]
+    ptsx = points(columnspace(d,1), n)
+    ptst = points(factor(d,2), m)
+
+    T = promote_eltypeof(ptsx, ptst)
+
+    if k == 1
+        repeat(ptsx, 1, m)
+    else # k == 2
+        repeat(reshape(ptst, 1, m), n)
+    end
 end
 
 

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -572,11 +572,13 @@ function points(d::BivariateSpace,n,m,k)
 
     T = promote_eltypeof(ptsx, ptst)
 
-    if k == 1
+    A = if k == 1
         repeat(ptsx, 1, m)
     else # k == 2
         repeat(reshape(ptst, 1, m), n)
     end
+
+    convert(AbstractArray{T}, A)
 end
 
 

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -295,6 +295,13 @@ using LinearAlgebra
             @test a == a
             @test a != b
         end
+
+        @testset "points" begin
+            S = PointSpace(1:4) ⊗ PointSpace(1:4)
+            P = points(S, 4, 4)
+            @test P[1] == repeat(1:4, 1, 4)
+            @test P[2] == repeat((1:4)', 4, 1)
+        end
     end
 
     @testset "ConstantSpace" begin


### PR DESCRIPTION
Fix #602

After this,
```julia
julia> S = Chebyshev(1..2)⊗Chebyshev(3..4)
Chebyshev(1 .. 2) ⊗ Chebyshev(3 .. 4)

julia> [p ∈ domain(factor(S, 1)) for p in points(S, 10, 10)[1]]
10×10 Matrix{Bool}:
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1

julia> [p ∈ domain(factor(S, 2)) for p in points(S, 10, 10)[2]]
10×10 Matrix{Bool}:
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1
```