### PR TITLE
Fix type instability in constructors.jl

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -117,7 +117,7 @@ function _default_Fun(f, d::Space)
         cf = default_Fun(f, d, 2^logn, Val(false))
         maxabsc = maximum(abs,cf.coefficients)
         if maxabsc == 0 && maxabsfr == 0
-            return zeros(d)
+            return zeros(T, d)
         end
 
         b = block(d,length(cf.coefficients))


### PR DESCRIPTION
Small bugfix, just missing a type parameter in `zeros`.

Before this PR:
```julia
julia> using ApproxFunBase, ApproxFun

julia> @code_warntype Fun(exp, Chebyshev(big(-1.0) .. big(1.0)))
MethodInstance for Fun(::typeof(exp), ::Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat})
  from Fun(f, d::Space) @ ApproxFunBase ~/.julia/dev/ApproxFunBase/src/constructors.jl:225
Arguments
  #self#::Type{Fun}
  f::Core.Const(exp)
  d::Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}
Body::Union{Fun{Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}, Float64, Vector{Float64}}, Fun{Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}, BigFloat, Vector{BigFloat}}}
1 ─ %1 = ApproxFunBase.default_Fun(f, d)::Union{Fun{Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}, Float64, Vector{Float64}}, Fun{Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}, BigFloat, Vector{BigFloat}}}
└──      return %1
```

After this PR:
```julia
julia> @code_warntype Fun(exp, Chebyshev(big(-1.0) .. big(1.0)))
MethodInstance for Fun(::typeof(exp), ::Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat})
  from Fun(f, d::Space) @ ApproxFunBase ~/.julia/dev/ApproxFunBase/src/constructors.jl:225
Arguments
  #self#::Type{Fun}
  f::Core.Const(exp)
  d::Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}
Body::Fun{Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}, BigFloat, Vector{BigFloat}}
1 ─ %1 = ApproxFunBase.default_Fun(f, d)::Fun{Chebyshev{IntervalSets.ClosedInterval{BigFloat}, BigFloat}, BigFloat, Vector{BigFloat}}
└──      return %1
```