### PR TITLE
First/last for ConstantSpace Fun

### DIFF
--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -81,7 +81,8 @@ ones(S::Union{AnyDomain,UnsetSpace}) = ones(ConstantSpace())
 zeros(S::AnyDomain) = zero(ConstantSpace())
 zero(S::UnsetSpace) = zero(ConstantSpace())
 _first_or_zero(f::AbstractVector) = get(f, 1, zero(eltype(f)))
-function evaluate(f::AbstractVector,::ConstantSpace,x...)
+function evaluate(f::AbstractVector, sp::ConstantSpace, x)
+    x in domain(sp) || return zero(eltype(f))
     _first_or_zero(f)
 end
 evaluate(f::AbstractVector,::ZeroSpace,x...)=zero(eltype(f))
@@ -155,6 +156,9 @@ coefficients(f::AbstractVector, sp::ConstantSpace{<:Domain{<:Number}}, ts::Space
 coefficients(f::AbstractVector, sp::ConstantSpace, ts::Space) =
     f[1]*ones(ts).coefficients
 
+# a Fun{<:ConstantSpace} corresponds to a constant value within the domain, irrespective of the domain
+first(f::Fun{<:ConstantSpace}) = convert(Number, f)
+last(f::Fun{<:ConstantSpace}) = convert(Number, f)
 
 ########
 # Evaluation

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -318,7 +318,7 @@ using LinearAlgebra
         @test 1 < f < 3
         @test differentiate(f) == Fun(0, ConstantSpace(0..1))
         @test f(-1) == 0
-        @test first(f) == last(f) == 1
+        @test first(f) == last(f) == 2
 
         f = Fun(2, ConstantSpace())
         @test first(f) == last(f) == 2

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -317,6 +317,11 @@ using LinearAlgebra
         @test g >= f
         @test 1 < f < 3
         @test differentiate(f) == Fun(0, ConstantSpace(0..1))
+        @test f(-1) == 0
+        @test first(f) == last(f) == 1
+
+        f = Fun(2, ConstantSpace())
+        @test first(f) == last(f) == 2
 
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(Point(2))) == ConstantSpace(Point(1) ∪ Point(2))
         @test maxspace(ConstantSpace(Point(1)), ConstantSpace(AnyDomain())) == ConstantSpace(Point(1))


### PR DESCRIPTION
Also, evaluating a `Fun{<:ConstantSpace}` outside the domain will return zero after this, which is consistent with how other spaces behave.