### PR TITLE
Add isconstantfun and check while converting to ConstantSpace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.23"
+version = "0.9.24"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -107,7 +107,8 @@ julia> coefficients(f, Legendre()) ≈ [0, 0, 1]
 true
 ```
 """
-function coefficients(f::Fun,msp::Space)
+coefficients(f::Fun,msp::Space) = _coefficients(f::Fun,msp::Space)
+function _coefficients(f::Fun,msp::Space)
     #zero can always be converted
     fc = f.coefficients
     if ncoefficients(f) == 0 || (ncoefficients(f) == 1 && fc[1] == 0)
@@ -774,7 +775,10 @@ isreal(f::Fun) = false
 
 iszero(f::Fun)    = all(iszero,f.coefficients)
 
-
+# Deliberately not named isconst or isconstant to avoid conflicts with Base or DomainSets
+isconstantfun(f::Fun) = _isconstantfun(containsconstant(space(f)), f)
+_isconstantfun(::Val{true}, f) = iszero(f - first(f))
+_isconstantfun(::Val{false}, f) = false
 
 # sum, integrate, and idfferentiate are in CalculusOperator
 

--- a/src/Fun.jl
+++ b/src/Fun.jl
@@ -776,9 +776,7 @@ isreal(f::Fun) = false
 iszero(f::Fun)    = all(iszero,f.coefficients)
 
 # Deliberately not named isconst or isconstant to avoid conflicts with Base or DomainSets
-isconstantfun(f::Fun) = _isconstantfun(containsconstant(space(f)), f)
-_isconstantfun(::Val{true}, f) = iszero(f - first(f))
-_isconstantfun(::Val{false}, f) = false
+isconstantfun(f::Fun) = iszero(f - first(f))
 
 # sum, integrate, and idfferentiate are in CalculusOperator
 

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -93,6 +93,7 @@ convert(::Type{T}, f::Fun{CS}) where {CS<:ConstantSpace,T<:Number} =
 
 Number(f::Fun) = strictconvert(Number, f)
 
+isconstantfun(f::Fun{<:ConstantSpace}) = true
 
 # promoting numbers to Fun
 # override promote_rule if the space type can represent constants
@@ -144,6 +145,10 @@ function getindex(C::ConcreteConversion{CS,S,T},k::Integer,j::Integer) where {CS
     k ≤ ncoefficients(on) ? strictconvert(T,on.coefficients[k]) : zero(T)
 end
 
+function coefficients(f::Fun, msp::ConstantSpace)
+    isconstantfun(f) || throw(ArgumentError("cannot convert a non-constant Fun to ConstantSpace"))
+    _coefficients(f, msp)
+end
 
 coefficients(f::AbstractVector,sp::ConstantSpace{Segment{SVector{2,TT}}},
              ts::TensorSpace{SV,DD}) where {TT,SV,DD<:EuclideanDomain{2}} =

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -319,6 +319,7 @@ using LinearAlgebra
         @test differentiate(f) == Fun(0, ConstantSpace(0..1))
         @test f(-1) == 0
         @test first(f) == last(f) == 2
+        @test ApproxFunBase.isconstantfun(f)
 
         f = Fun(2, ConstantSpace())
         @test first(f) == last(f) == 2


### PR DESCRIPTION
After this, coefficients for non-constant `Fun`s can't be evaluated in a `ConstantSpace`.
The following works on master, but will be disallowed:
```julia
julia> coefficients(Fun(Chebyshev(0..1)), ConstantSpace(0..1))
2-element Vector{Float64}:
  0.5
 Inf
```
The newly added function `isconstantfun` is intended to be extended by downstream packages to provide more efficient implementations.