### PR TITLE
Evaluate Fun{<:PointSpace} using a Point

### DIFF
--- a/src/Spaces/DiracSpace.jl
+++ b/src/Spaces/DiracSpace.jl
@@ -79,8 +79,11 @@ Fun(::typeof(identity), S::DiracSpace) = Fun(PointSpace(S.points),S.points)
 transform(S::PointSpace,v::AbstractVector,plan...) = v
 values(f::Fun{S}) where S<:PointSpace = coefficient(f,:)
 
-function evaluate(f::AbstractVector,PS::PointSpace,x::Number)
-    p = findfirst(y->isapprox(x,y),PS.points)
+first(f::Fun{<:PointSpace}) = coefficients(f)[1]
+last(f::Fun{<:PointSpace}) = coefficients(f)[end]
+
+function evaluate(f::AbstractVector, PS::PointSpace, x)
+    p = findfirst(y->isapprox(convert(Number,x), y), PS.points)
     if p === nothing
         zero(eltype(f))
     else
@@ -88,10 +91,8 @@ function evaluate(f::AbstractVector,PS::PointSpace,x::Number)
     end
 end
 
-function evaluate(f::AbstractVector, PS::DiracSpace, x::Number)
-    x ∉ domain(PS) && return zero(eltype(f))
-
-    p = findfirst(y->isapprox(x,y), PS.points)
+function evaluate(f::AbstractVector, PS::DiracSpace, x)
+    p = findfirst(y->isapprox(convert(Number, x), y), PS.points)
     if p === nothing
         zero(eltype(f))
     else
@@ -100,7 +101,7 @@ function evaluate(f::AbstractVector, PS::DiracSpace, x::Number)
 end
 
 Base.sum(f::Fun{DS}) where DS<:DiracSpace =
-    sum(f.coefficients[1:dimension(space(f))])
+    sum(@view f.coefficients[1:dimension(space(f))])
 
 DiracDelta(x::Number)=Fun(DiracSpace(x),[1.])
 DiracDelta()=DiracDelta(0.)

--- a/src/Spaces/DiracSpace.jl
+++ b/src/Spaces/DiracSpace.jl
@@ -83,7 +83,7 @@ first(f::Fun{<:PointSpace}) = coefficients(f)[1]
 last(f::Fun{<:PointSpace}) = coefficients(f)[end]
 
 function evaluate(f::AbstractVector, PS::PointSpace, x)
-    p = findfirst(y->isapprox(convert(Number,x), y), PS.points)
+    p = findfirst(≈(convert(Number,x)), PS.points)
     if p === nothing
         zero(eltype(f))
     else
@@ -92,7 +92,7 @@ function evaluate(f::AbstractVector, PS::PointSpace, x)
 end
 
 function evaluate(f::AbstractVector, PS::DiracSpace, x)
-    p = findfirst(y->isapprox(convert(Number, x), y), PS.points)
+    p = findfirst(≈(convert(Number,x)), PS.points)
     if p === nothing
         zero(eltype(f))
     else

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -1,9 +1,10 @@
 using ApproxFunBase
-using Test
 using ApproxFunBase: PointSpace, HeavisideSpace, PiecewiseSegment, dimension, SVector, checkpoints, AnyDomain
-using StaticArrays
 using BandedMatrices: rowrange, colrange, BandedMatrix
+using DomainSets: Point
 using LinearAlgebra
+using StaticArrays
+using Test
 
 @testset "Spaces" begin
     @testset "PointSpace" begin
@@ -11,6 +12,9 @@ using LinearAlgebra
 
         f = @inferred Fun(x->(x-0.1),PointSpace([0,0.1,1]))
         @test roots(f) == [0.1]
+        @test first(f) == -0.1
+        @test last(f) == 0.9
+        @test f(Point(0)) == -0.1
 
         a = @inferred Fun(exp, space(f))
         @test f/a == @inferred Fun(x->(x-0.1)*exp(-x),space(f))
@@ -212,6 +216,7 @@ using LinearAlgebra
         @test f(0.5) == 0
         @test f(5) == 0
         @test isinf(f(0))
+        @test isinf(f(Point(0)))
     end
 
     @testset "Derivative operator for HeavisideSpace" begin

--- a/test/SpacesTest.jl
+++ b/test/SpacesTest.jl
@@ -217,6 +217,7 @@ using Test
         @test f(5) == 0
         @test isinf(f(0))
         @test isinf(f(Point(0)))
+        @test sum(f) == 6
     end
 
     @testset "Derivative operator for HeavisideSpace" begin


### PR DESCRIPTION
Since a `Point` may be converted to a `Number`, we may allow evaluating a `Fun{<:PointSpace}` at a point as well, so that the following works now:
```julia
julia> f = Fun(PointSpace(1:3))
Fun(PointSpace([1, 2, 3]), [1, 2, 3])

julia> f(Point(1))
1
``` 