### PR TITLE
Convert ApproxFunBaseTest to a package extension

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main(; subdirs=["", "ApproxFunBaseTest"])
+          CompatHelper.main()
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -45,6 +45,6 @@ jobs:
           version: ${{ matrix.version }}
       - uses: cjdoris/julia-downgrade-compat-action@v1
         with:
-          skip: LinearAlgebra,SparseArrays,Statistics
+          skip: LinearAlgebra,SparseArrays,Statistics,Test
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -63,7 +63,6 @@ jobs:
           try
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.develop(PackageSpec(path="ApproxFunBaseTest"))
             Pkg.update()
             Pkg.test(; coverage = "@src")  # resolver may fail with test time deps
           catch err

--- a/ApproxFunBaseTest/README.md
+++ b/ApproxFunBaseTest/README.md
@@ -1,0 +1,1 @@
+This package is now deprecated in favor of a package extension at `ext/ApproxFunBaseTestExt.jl`

--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,12 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[weakdeps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[extensions]
+ApproxFunBaseTestExt = "Test"
+
 [compat]
 AbstractFFTs = "0.5, 1"
 Aqua = "0.8"

--- a/ext/ApproxFunBaseTestExt.jl
+++ b/ext/ApproxFunBaseTestExt.jl
@@ -1,0 +1,266 @@
+module ApproxFunBaseTestExt
+
+using ApproxFunBase
+using Test
+using ApproxFunBase: plan_transform, plan_itransform, israggedbelow, RaggedMatrix, isbandedbelow, isbanded,
+    blockstart, blockstop, resizedata!
+using ApproxFunBase.BandedMatrices: BandedMatrices, rowstart, rowstop, colstart, colstop, BandedMatrix, bandwidth
+using ApproxFunBase.BlockArrays: blockrowstop, blockcolstop, Block
+using ApproxFunBase.BlockBandedMatrices: isbandedblockbanded, blockbandwidth, isblockbanded, subblockbandwidth
+using ApproxFunBase.DomainSets: dimension
+using ApproxFunBase.InfiniteArrays
+using ApproxFunBase.LinearAlgebra
+
+import ApproxFunBase.TestUtils: testspace, testfunctional, testraggedbelowoperator, testbandedblockbandedoperator,
+    testbandedoperator, testtransforms, testcalculus, testmultiplication, testinfoperator,
+    testblockbandedoperator, testbandedbelowoperator
+
+# assert type in convert
+strictconvert(::Type{T}, x) where {T} = convert(T, x)::T
+
+## Spaces Tests
+
+
+function testtransforms(S::Space;minpoints=1,invertibletransform=true)
+    # transform tests
+    v = rand(max(minpoints,min(100,dimension(S))))
+    plan = plan_transform(S,v)
+    @test transform(S,v)  == plan*v
+
+    iplan = plan_itransform(S,v)
+    @test itransform(S,v)  == iplan*v
+
+    if invertibletransform
+        for k=max(1,minpoints):min(5,dimension(S))
+            v = [zeros(k-1);1.0]
+            @test transform(S,itransform(S,v)) ≈ v
+        end
+
+        @test transform(S,itransform(S,v)) ≈ v
+        @test itransform(S,transform(S,v)) ≈ v
+    end
+end
+
+function testcalculus(S::Space;haslineintegral=true,hasintegral=true)
+    @testset for k=1:min(5,dimension(S))
+        v = [zeros(k-1);1.0]
+        f = Fun(S,v)
+        @test abs(DefiniteIntegral()*f-sum(f)) < 100eps()
+        if haslineintegral
+            @test DefiniteLineIntegral()*f ≈ linesum(f)
+        end
+        @test norm(Derivative()*f-f') < 100eps()
+        if hasintegral
+            @test norm(differentiate(integrate(f))-f) < 100eps()
+            @test norm(differentiate(cumsum(f))-f) < 200eps()
+            @test norm(first(cumsum(f))) < 100eps()
+        end
+    end
+end
+
+function testmultiplication(spa,spb)
+    @testset for k=1:10
+        a = Fun(spa,[zeros(k-1);1.])
+        M = Multiplication(a,spb)
+        pts = ApproxFunBase.checkpoints(rangespace(M))
+        for j=1:10
+            b = Fun(spb,[zeros(j-1);1.])
+            @test (M*b).(pts) ≈ a.(pts).*b.(pts)
+        end
+    end
+end
+
+function testspace(S::Space;
+                    minpoints=1,invertibletransform=true,haslineintegral=true,hasintegral=true,
+                    dualspace=S)
+    testtransforms(S;minpoints=minpoints,invertibletransform=invertibletransform)
+    testcalculus(S;haslineintegral=haslineintegral,hasintegral=hasintegral)
+    if dualspace ≠ nothing
+        testmultiplication(dualspace,S)
+    end
+end
+
+
+
+
+
+## Operator Tests
+
+function backend_testfunctional(A)
+    @test rowstart(A,1) ≥ 1
+    @test colstop(A,1) ≤ 1
+    @test bandwidth(A,1) ≤ 0
+    @test blockbandwidth(A,1) ≤ 0
+
+    B=A[1:10]
+    @test eltype(B) == eltype(A)
+    for k=1:5
+        @test B[k] ≈ A[k]
+        @test isa(A[k],eltype(A))
+    end
+    @test isa(A[1,1:10],Vector)
+    @test isa(A[1:1,1:10],AbstractMatrix)
+    @test B ≈ A[1,1:10]
+    @test transpose(B) ≈ A[1:1,1:10]
+    @test B[3:10] ≈ A[3:10]
+    @test B ≈ [A[k] for k=1:10]
+
+
+
+    co=cache(A)
+    @test co[1:10] ≈ A[1:10]
+    @test co[1:10] ≈ A[1:10]
+    @test co[20:30] ≈ A[1:30][20:30] ≈ A[20:30]
+end
+
+# Check that the tests pass after conversion as well
+function testfunctional(A::Operator{T}) where T<:Real
+    backend_testfunctional(A)
+    backend_testfunctional(Operator{Float64}(A))
+    backend_testfunctional(Operator{Float32}(A))
+    backend_testfunctional(Operator{ComplexF64}(A))
+end
+
+function testfunctional(A::Operator{T}) where T<:Complex
+    backend_testfunctional(A)
+    backend_testfunctional(Operator{ComplexF32}(A))
+    backend_testfunctional(Operator{ComplexF64}(A))
+end
+
+function backend_testinfoperator(A)
+    @test isinf(size(A,1))
+    @test isinf(size(A,2))
+    B=A[1:5,1:5]
+    @test eltype(B) == eltype(A)
+
+    for k=1:5,j=1:5
+        @test B[k,j] ≈ A[k,j]
+        @test isa(A[k,j],eltype(A))
+    end
+
+    A10 = A[1:10,1:10]
+    A10m = Matrix(A10)
+    A10_510 = A10m[5:10,5:10]
+    A30 = A[1:30,1:30]
+    A30_2030 = A30[20:30,20:30]
+    A30_2030m = Matrix(A30_2030)
+
+    @test Matrix(B[2:5,1:5]) ≈ Matrix(A[2:5,1:5])
+    @test Matrix(A[1:5,2:5]) ≈ Matrix(B[:,2:end])
+    @test A10_510 ≈ [A[k,j] for k=5:10,j=5:10]
+    @test A10_510 ≈ Matrix(A[5:10,5:10])
+    @test A30_2030m ≈ Matrix(A[20:30,20:30])
+
+    @test Matrix(A[Block(1):Block(3),Block(1):Block(3)]) ≈ Matrix(A[blockstart(rangespace(A),1):blockstop(rangespace(A),3),blockstart(domainspace(A),1):blockstop(domainspace(A),3)])
+    @test Matrix(A[Block(3):Block(4),Block(2):Block(4)]) ≈ Matrix(A[blockstart(rangespace(A),3):blockstop(rangespace(A),4),blockstart(domainspace(A),2):blockstop(domainspace(A),4)])
+
+    for k=1:10
+        @test isfinite(colstart(A,k)) && colstart(A,k) > 0
+        @test isfinite(rowstart(A,k)) && colstart(A,k) > 0
+    end
+
+    co=cache(A)
+    @test Matrix(co[1:10,1:10]) ≈ A10m
+    @test Matrix(co[20:30,20:30]) ≈ A30_2030m
+
+    let C=cache(A)
+        resizedata!(C,5,35)
+        resizedata!(C,10,35)
+        @test Matrix(C.data[1:10,1:C.datasize[2]]) ≈ Matrix(A[1:10,1:C.datasize[2]])
+    end
+end
+
+# Check that the tests pass after conversion as well
+function testinfoperator(A::Operator{T}) where T<:Real
+    backend_testinfoperator(A)
+    if T != Float64
+        B = strictconvert(Operator{Float64}, A)
+        backend_testinfoperator(B)
+    end
+    if T != Float32
+        B = strictconvert(Operator{Float32}, A)
+        backend_testinfoperator(B)
+    end
+    B = strictconvert(Operator{ComplexF64}, A)
+    backend_testinfoperator(B)
+end
+
+function testinfoperator(A::Operator{T}) where T<:Complex
+    backend_testinfoperator(A)
+    if T != ComplexF32
+        backend_testinfoperator(strictconvert(Operator{ComplexF32}, A))
+    end
+    if T != ComplexF64
+        backend_testinfoperator(strictconvert(Operator{ComplexF64}, A))
+    end
+end
+
+function testraggedbelowoperator(A)
+    @test israggedbelow(A)
+    for k=1:20
+        @test isfinite(colstop(A,k))
+    end
+
+    R = RaggedMatrix(view(A, 1:10, 1:min(10,size(A,2))))
+    for j=1:size(R,2)
+        @test colstop(R,j) == min(colstop(A,j),10)
+    end
+
+    testinfoperator(A)
+end
+
+function testbandedbelowoperator(A)
+    @test isbandedbelow(A)
+    @test isfinite(bandwidth(A,1))
+    testraggedbelowoperator(A)
+
+    for k=1:10
+        @test colstop(A,k) ≤ max(0,k + bandwidth(A,1))
+    end
+end
+
+
+function testalmostbandedoperator(A)
+    testbandedbelowoperator(A)
+end
+
+function testbandedoperator(A)
+    @test isbanded(A)
+    @test isfinite(bandwidth(A,2))
+    testalmostbandedoperator(A)
+    for k=1:10
+        @test rowstop(A,k) ≤ k + bandwidth(A,2)
+    end
+
+    Am = A[1:10,1:10]
+    @test Am isa AbstractMatrix && BandedMatrices.isbanded(Am)
+end
+
+
+function testblockbandedoperator(A)
+    @test isblockbanded(A)
+    testraggedbelowoperator(A)
+    @test isfinite(blockbandwidth(A,2))
+    @test isfinite(blockbandwidth(A,1))
+
+
+    if -blockbandwidth(A,1) ≤ blockbandwidth(A,2)
+        for K=1:10
+            @test K - blockbandwidth(A,2) ≤ blockcolstop(A,Block(K)).n[1] ≤ K + blockbandwidth(A,1) < ∞
+            @test K - blockbandwidth(A,1) ≤ blockrowstop(A,Block(K)).n[1] ≤ K + blockbandwidth(A,2) < ∞
+        end
+    end
+end
+
+function testbandedblockbandedoperator(A)
+    @test isbandedblockbanded(A)
+    testblockbandedoperator(A)
+    @test isfinite(subblockbandwidth(A,1))
+    @test isfinite(subblockbandwidth(A,2))
+
+    Am = A[Block.(1:4),Block.(1:4)]
+    @test Am isa AbstractMatrix && isbandedblockbanded(Am)
+end
+
+
+end

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -166,5 +166,6 @@ include("eigen.jl")
 include("hacks.jl")
 include("specialfunctions.jl")
 include("show.jl")
+include("testutils.jl")
 
 end #module

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -1,0 +1,29 @@
+module TestUtils
+
+export testspace, testfunctional, testraggedbelowoperator, testbandedblockbandedoperator,
+    testbandedoperator, testtransforms, testcalculus, testmultiplication, testinfoperator,
+    testblockbandedoperator, testbandedbelowoperator
+
+function testspace end
+
+function testfunctional end
+
+function testraggedbelowoperator end
+
+function testbandedblockbandedoperator end
+
+function testbandedoperator end
+
+function testtransforms end
+
+function testcalculus end
+
+function testmultiplication end
+
+function testinfoperator end
+
+function testblockbandedoperator end
+
+function testbandedbelowoperator end
+
+end

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -1,5 +1,7 @@
 module TestUtils
 
+# methods to the functions defined here are added in ext/ApproxFunBaseTestExt.jl
+
 export testspace, testfunctional, testraggedbelowoperator, testbandedblockbandedoperator,
     testbandedoperator, testtransforms, testcalculus, testmultiplication, testinfoperator,
     testblockbandedoperator, testbandedbelowoperator


### PR DESCRIPTION
After this, downstream packages don't need to depend explicitly on `ApproxFunBaseTest`, but may instead depend on the internal module `ApproxFunBase.TestUtils`, which is equivalent in functionality. The advantage is that the methods are defined in a package extension, so the package does not need to be maintained separately.  