### PR TITLE
Explicitly import `Number` before extending it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ApproxFunBase"
 uuid = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
-version = "0.9.32"
+version = "0.9.33"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ApproxFunBase.jl
+++ b/src/ApproxFunBase.jl
@@ -48,7 +48,7 @@ import Base: values, convert, getindex, setindex!, *, +, -, ==, <, <=, >, |, !,
               sinc, cosc, log1p, log, expm1, tan,
               max, min, cbrt, atan, acos, asin, chop,
               axes, IndexStyle, IndexLinear, typed_hcat, parent,
-              AbstractMatrix, AbstractVector
+              AbstractMatrix, AbstractVector, Number
 
 import Base.Broadcast: BroadcastStyle, Broadcasted, AbstractArrayStyle,
               broadcastable, DefaultArrayStyle, broadcasted


### PR DESCRIPTION
Since a method to `Number` is being added in this package, it needs to be imported explicitly.